### PR TITLE
Fix typos

### DIFF
--- a/rstan/rstan/inst/include/rstan/stan_args.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_args.hpp
@@ -304,10 +304,10 @@ namespace rstan {
     bool get_sample_file_flag() const { 
       return sample_file_flag; 
     }
-    bool get_dianositic_file_flag() const {
+    bool get_diagnostic_file_flag() const {
       return diagnostic_file_flag;
     } 
-    const std::string& get_dianositic_file() const {
+    const std::string& get_diagnostic_file() const {
       return diagnostic_file;
     } 
     int get_warmup() const {

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -506,9 +506,9 @@ namespace rstan {
                         const std::vector<size_t>& midx, 
                         const std::vector<std::string>& fnames_oi, RNG& base_rng) {
       bool sample_file_flag = args.get_sample_file_flag(); 
-      bool diagnostic_file_flag = args.get_dianositic_file_flag();
+      bool diagnostic_file_flag = args.get_diagnostic_file_flag();
       std::string sample_file = args.get_sample_file(); 
-      std::string diagnostic_file = args.get_dianositic_file();
+      std::string diagnostic_file = args.get_diagnostic_file();
       int num_iterations = args.get_iter(); 
       int num_warmup = args.get_warmup(); 
       int num_thin = args.get_thin(); 

--- a/rstan/rstan/man/stan_model.Rd
+++ b/rstan/rstan/man/stan_model.Rd
@@ -32,7 +32,7 @@
 
   \item{model_code}{A character string either containing the model 
     specification or the name of a character string object in the workspace;
-    an alterantive is to specify the model with parameters \code{file}
+    an alternative is to specify the model with parameters \code{file}
     or \code{stanc_ret}. 
   }
   \item{stanc_ret}{A named list returned from a previous call to 

--- a/rstan/rstan/man/stanc.Rd
+++ b/rstan/rstan/man/stanc.Rd
@@ -33,7 +33,7 @@ Translate Stan model specification to C++ code
       are given the same, the generated C++ code will have the same class
       name defining the model, and the same Rcpp module name, which is used 
       for R to execute the C++ code regardless if the stan models are the 
-      same of not. Generally, it is recommented not to specify this parameter 
+      same of not. Generally, it is recommended not to specify this parameter
       or set it to \code{TRUE}. 
     }
   }


### PR DESCRIPTION
Fixes two documentation typos and one function name typo.
