### PR TITLE
Reduce compiler warnings by using -isystem instead of -I for library includes

### DIFF
--- a/rstan/rstan/src/Makefile
+++ b/rstan/rstan/src/Makefile
@@ -14,9 +14,9 @@ EIGEN_PATH = $(shell find ../inst/include/stanlib -path '*lib/eigen_*' -regex '.
 
 PKG_LIBS = $(shell  $(R_HOME)/bin/Rscript --vanilla -e "Rcpp:::LdFlags()") 
 PKG_CPPFLAGS += -I"../inst/include/stansrc"  
-PKG_CPPFLAGS += -I"$(EIGEN_PATH)" 
-PKG_CPPFLAGS += -I"$(EIGEN_PATH)/unsupported" 
-PKG_CPPFLAGS += -I$(shell find ../inst/include/stanlib -path '*lib/boost_*' -regex '.*lib\/boost_[^/]*')
+PKG_CPPFLAGS += -isystem"$(EIGEN_PATH)" 
+PKG_CPPFLAGS += -isystem"$(EIGEN_PATH)/unsupported" 
+PKG_CPPFLAGS += -isystem$(shell find ../inst/include/stanlib -path '*lib/boost_*' -regex '.*lib\/boost_[^/]*')
 PKG_CPPFLAGS += -I"../inst/include" 
 PKG_CPPFLAGS += -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS
 PKG_CPPFLAGS += -ftemplate-depth-256


### PR DESCRIPTION
Fixes #24.

I verified this works by typing:

``` text
cd rstan
make install
```
