### PR TITLE
force rho_hat to be 0 if it is NaN due to the variable being constant

### DIFF
--- a/rstan/rstan/R/monitor.R
+++ b/rstan/rstan/R/monitor.R
@@ -36,6 +36,7 @@ ess_rfun <- function(sims) {
   rho_hat_sum <- 0
   for (t in 2:nrow(acov)) {
     rho_hat <- 1 - (mean_var - mean(acov[t, ])) / var_plus
+    if (is.nan(rho_hat)) rho_hat <- 0
     if (rho_hat < 0) break
     rho_hat_sum <- rho_hat_sum + rho_hat
   } 


### PR DESCRIPTION
Fix problem with monitor() on a constant variable that Sebastian encountered here:
https://groups.google.com/d/msg/stan-users/HBewhdW1u88/tAcAIkiFdV4J
