### PR TITLE
Remove trailing whitespace from RStan hpp files

### DIFF
--- a/rstan/rstan/inst/include/rstan/io/r_ostream.hpp
+++ b/rstan/rstan/inst/include/rstan/io/r_ostream.hpp
@@ -8,16 +8,16 @@
 #include <R_ext/Print.h>
 
 /**
- * Similar version of both std::cout and std::cerr are implemented for 
+ * Similar version of both std::cout and std::cerr are implemented for
  * RStan to write to cout and cerr of R.
  *
- * See 
+ * See
  * http://gcc.gnu.org/onlinedocs/libstdc++/manual/bk01pt11ch25.html#io.streambuf.derived
- * http://goo.gl/mKmeP 
+ * http://goo.gl/mKmeP
  * and http://www.cplusplus.com/reference/iostream/streambuf/overflow/
- * 
- * 
- */ 
+ *
+ *
+ */
 
 namespace rstan {
 
@@ -25,25 +25,25 @@ namespace rstan {
 
     class r_cout_streambuf : public std::streambuf {
     public:
-      r_cout_streambuf() {} 
+      r_cout_streambuf() {}
 
     protected:
       /**
        * @param  c  An additional character to consume.
        * @return  EOF to indicate failure, something else (usually
        *          @a c, or not_eof())
-       */ 
+       */
       virtual int_type overflow(int_type  c) {
-        if (c != EOF) 
+        if (c != EOF)
           Rprintf("%c", c);
-        return c; 
+        return c;
       }
- 
+
       virtual int sync() {
          R_FlushConsole();
          R_ProcessEvents();
          return 0;
-      } 
+      }
 
       virtual std::streamsize xsputn(const char_type* s, std::streamsize n) {
         Rprintf("%.*s", n, s);
@@ -53,20 +53,20 @@ namespace rstan {
 
     class r_cerr_streambuf : public std::streambuf {
     public:
-      r_cerr_streambuf() {} 
+      r_cerr_streambuf() {}
 
     protected:
       virtual int_type overflow(int_type c) {
-        if (c != EOF) 
+        if (c != EOF)
           REprintf("%c", c);
         return c;
       }
-      
+
       virtual int sync() {
          R_FlushConsole();
          R_ProcessEvents();
          return 0;
-      } 
+      }
 
       virtual std::streamsize xsputn(const char_type* s, std::streamsize n) {
         REprintf("%.*s", n, s);
@@ -88,15 +88,15 @@ namespace rstan {
 
     /**
      * Define global rstan::io::rcout and rstan::io::rcerr,
-     * which can be used similarly as std::cout and std::cerr.  
-     * 
+     * which can be used similarly as std::cout and std::cerr.
+     *
      */
-    // extern 
-    static r_ostream<r_cout_streambuf> rcout(false); 
-    // extern 
-    static r_ostream<r_cerr_streambuf> rcerr(true); 
+    // extern
+    static r_ostream<r_cout_streambuf> rcout(false);
+    // extern
+    static r_ostream<r_cerr_streambuf> rcerr(true);
   }
 
-} 
+}
 
-#endif 
+#endif

--- a/rstan/rstan/inst/include/rstan/io/rlist_ref_var_context.hpp
+++ b/rstan/rstan/inst/include/rstan/io/rlist_ref_var_context.hpp
@@ -33,17 +33,17 @@ namespace rstan {
       }
       */
 
-      template <class T1, class T2> 
+      template <class T1, class T2>
       void  T1v_to_T2v(const std::vector<T1>& v,
                        std::vector<T2>& v2) {
-        v2.resize(0); 
+        v2.resize(0);
         for (typename std::vector<T1>::const_iterator it = v.begin();
              it != v.end();
-             ++it) { 
+             ++it) {
           v2.push_back(static_cast<T2>(*it));
-        }     
-      } 
-    } 
+        }
+      }
+    }
 
     /**
      * Represents named arrays with dimensions.
@@ -53,25 +53,25 @@ namespace rstan {
      * vector, array) with dimensions.  The values for
      * an array are typed to double or int.  However,
      * it is R's job to pass data with correct types
-     * though R uses double as the default atomic type. 
-     * Instead of copying the data as in 
-     * <code>rlist_var_context</code>, data are 
-     * obtained by references. 
-     * 
-     * <p>The dimensions and values of variables
-     * may be accessed by name. 
+     * though R uses double as the default atomic type.
+     * Instead of copying the data as in
+     * <code>rlist_var_context</code>, data are
+     * obtained by references.
      *
-     * <p> Difference from <code>rlist_var_context</code>: 
-     * here, when the object is constructed, we only 
+     * <p>The dimensions and values of variables
+     * may be accessed by name.
+     *
+     * <p> Difference from <code>rlist_var_context</code>:
+     * here, when the object is constructed, we only
      * keep in the information of dimensions (the same as
-     * in rlist_var_context) but the data are not copied. The 
-     * data are accessed directly from the R list. 
+     * in rlist_var_context) but the data are not copied. The
+     * data are accessed directly from the R list.
      * T
      */
     class rlist_ref_var_context : public stan::io::var_context {
-    private: 
-      Rcpp::List rlist_; 
-      std::map<std::string, std::vector<size_t> > vars_r_dim_; 
+    private:
+      Rcpp::List rlist_;
+      std::map<std::string, std::vector<size_t> > vars_r_dim_;
       std::map<std::string, std::vector<size_t> > vars_i_dim_;
       std::vector<double> const empty_vec_r_;
       std::vector<int> const empty_vec_i_;
@@ -82,13 +82,13 @@ namespace rstan {
        * returns <code>false</code> if the values are all integers.
        *
        * @param name Variable name to test.
-       * @return <code>true</code> if the variable exists in the 
+       * @return <code>true</code> if the variable exists in the
        * real values of the rlist_ref_var_context.
        */
       bool contains_r_only(const std::string& name) const {
-        return vars_r_dim_.count(name) > 0; 
+        return vars_r_dim_.count(name) > 0;
       }
-    public: 
+    public:
 
       /**
        * Construct a rlist_ref__var_context object from the specified R list.
@@ -99,53 +99,53 @@ namespace rstan {
       rlist_ref_var_context(SEXP in): rlist_(in) {
 
         if (0 == rlist_.size()) return;
-        std::vector<std::string> varnames 
-          = Rcpp::as<std::vector<std::string> >(rlist_.names()); 
+        std::vector<std::string> varnames
+          = Rcpp::as<std::vector<std::string> >(rlist_.names());
         for (int i = 0; i < rlist_.size(); i++) {
-          SEXP ee = rlist_[i]; 
-          SEXP dim = Rf_getAttrib(ee, R_DimSymbol); 
-          R_len_t eelen = Rf_length(ee); 
+          SEXP ee = rlist_[i];
+          SEXP dim = Rf_getAttrib(ee, R_DimSymbol);
+          R_len_t eelen = Rf_length(ee);
 
           // Note that in R, the default is real, which causes problems as we
           // are thinking they are integers, but Rf_isInteger would return
           // FALSE. One solution is use L suffix. Anyway, the R code should
-          // change the data to integers when it is convertible. 
+          // change the data to integers when it is convertible.
 
-          typedef std::map<std::string, std::vector<size_t> >::value_type 
+          typedef std::map<std::string, std::vector<size_t> >::value_type
             psd_v_t; // a Pair of String and Dimensions
 
           if (Rf_isInteger(ee)) {
-            if (Rf_length(dim) > 0) { 
-              std::vector<size_t> d; 
-              T1v_to_T2v(Rcpp::as<std::vector<unsigned int> >(dim), d);     
-              vars_i_dim_.insert(psd_v_t(varnames[i], d)); 
+            if (Rf_length(dim) > 0) {
+              std::vector<size_t> d;
+              T1v_to_T2v(Rcpp::as<std::vector<unsigned int> >(dim), d);
+              vars_i_dim_.insert(psd_v_t(varnames[i], d));
             } else {
-              if (1 == eelen) {  // scalar 
-                vars_i_dim_.insert(psd_v_t(varnames[i], empty_vec_ui_)); 
-              } else { // vector 
-                vars_i_dim_.insert(psd_v_t(varnames[i], 
+              if (1 == eelen) {  // scalar
+                vars_i_dim_.insert(psd_v_t(varnames[i], empty_vec_ui_));
+              } else { // vector
+                vars_i_dim_.insert(psd_v_t(varnames[i],
                                            std::vector<size_t>(1, eelen)));
               }
-            } 
+            }
           } else if(Rf_isNumeric(ee)) {
-            if (Rf_length(dim) > 0) { 
-              std::vector<size_t> d; 
-              T1v_to_T2v(Rcpp::as<std::vector<unsigned int> >(dim), d);     
-              vars_r_dim_.insert(psd_v_t(varnames[i], d)); 
+            if (Rf_length(dim) > 0) {
+              std::vector<size_t> d;
+              T1v_to_T2v(Rcpp::as<std::vector<unsigned int> >(dim), d);
+              vars_r_dim_.insert(psd_v_t(varnames[i], d));
             } else {
-              if (1 == eelen) {  // scalar 
-                vars_r_dim_.insert(psd_v_t(varnames[i], empty_vec_ui_)); 
+              if (1 == eelen) {  // scalar
+                vars_r_dim_.insert(psd_v_t(varnames[i], empty_vec_ui_));
               } else {
-                vars_r_dim_.insert(psd_v_t(varnames[i], 
+                vars_r_dim_.insert(psd_v_t(varnames[i],
                                            std::vector<size_t>(1, eelen)));
               }
             }
           } else {
-            continue; // ignore non-numeric data 
-            // or should we report error? 
-          } 
-        } 
-      } 
+            continue; // ignore non-numeric data
+            // or should we report error?
+          }
+        }
+      }
 
       /**
        * Return <code>true</code> if this rlist_ref_var_context contains the
@@ -161,31 +161,31 @@ namespace rstan {
 
       /**
        * Return <code>true</code> if this rlist_ref_var_context contains an integer
-       * valued array with the specified name. 
+       * valued array with the specified name.
        *
        * @param name Variable name to test.
        * @return <code>true</code> if the variable name has an integer
        * array value.
        */
       bool contains_i(const std::string& name) const {
-        return vars_i_dim_.count(name) > 0; 
+        return vars_i_dim_.count(name) > 0;
       }
 
       /**
        * Return the double values for the variable with the specified
-       * name or null. 
+       * name or null.
        *
        * @param name Name of variable.
        * @return Values of variable.
        */
       std::vector<double> vals_r(const std::string& name) const {
-        if (contains_r(name)) { 
-          SEXP ee = rlist_[name]; 
-          return Rcpp::as<std::vector<double> >(ee); 
+        if (contains_r(name)) {
+          SEXP ee = rlist_[name];
+          return Rcpp::as<std::vector<double> >(ee);
         }
         return empty_vec_r_;
       }
-      
+
       /**
        * Return the dimensions for the double variable with the specified
        * name.
@@ -211,12 +211,12 @@ namespace rstan {
        */
       std::vector<int> vals_i(const std::string& name) const {
         if (contains_i(name)) {
-          SEXP ee = rlist_[name]; 
-          return Rcpp::as<std::vector<int> >(ee); 
+          SEXP ee = rlist_[name];
+          return Rcpp::as<std::vector<int> >(ee);
         }
         return empty_vec_i_;
       }
-      
+
       /**
        * Return the dimensions for the integer variable with the specified
        * name.
@@ -238,7 +238,7 @@ namespace rstan {
        * @param names Vector to store the list of names in.
        */
       virtual void names_r(std::vector<std::string>& names) const {
-        names.resize(0);        
+        names.resize(0);
         for (std::map<std::string, std::vector<size_t> >
                  ::const_iterator it = vars_r_dim_.begin();
              it != vars_r_dim_.end(); ++it)
@@ -252,20 +252,20 @@ namespace rstan {
        * @param names Vector to store the list of names in.
        */
       virtual void names_i(std::vector<std::string>& names) const {
-        names.resize(0);        
-        for (std::map<std::string, std::vector<size_t> > 
+        names.resize(0);
+        for (std::map<std::string, std::vector<size_t> >
                  ::const_iterator it = vars_i_dim_.begin();
              it != vars_i_dim_.end(); ++it)
           names.push_back((*it).first);
       }
 
       bool remove(const std::string& name) {
-        return (vars_i_dim_.erase(name) > 0) 
+        return (vars_i_dim_.erase(name) > 0)
           || (vars_r_dim_.erase(name) > 0);
       }
-      
+
     };
-    
+
 
   }
 

--- a/rstan/rstan/inst/include/rstan/rcpp_module_def_for_rstan.hpp
+++ b/rstan/rstan/inst/include/rstan/rcpp_module_def_for_rstan.hpp
@@ -1,41 +1,41 @@
 /**
- * Define Rcpp Module to expose stan_fit's functions to R. 
- */ 
+ * Define Rcpp Module to expose stan_fit's functions to R.
+ */
 RCPP_MODULE(stan_fit4%model_name%_mod){
-  Rcpp::class_<rstan::stan_fit<%model_name%_namespace::%model_name%, 
+  Rcpp::class_<rstan::stan_fit<%model_name%_namespace::%model_name%,
                boost::random::ecuyer1988> >("stan_fit4%model_name%")
-    // .constructor<Rcpp::List>() 
-    .constructor<SEXP, SEXP>() 
-    // .constructor<SEXP, SEXP>() 
-    .method("call_sampler", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::call_sampler) 
-    .method("param_names", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_names) 
-    .method("param_names_oi", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_names_oi) 
-    .method("param_fnames_oi", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_fnames_oi) 
-    .method("param_dims", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_dims) 
-    .method("param_dims_oi", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_dims_oi) 
-    .method("update_param_oi", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::update_param_oi) 
+    // .constructor<Rcpp::List>()
+    .constructor<SEXP, SEXP>()
+    // .constructor<SEXP, SEXP>()
+    .method("call_sampler",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::call_sampler)
+    .method("param_names",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_names)
+    .method("param_names_oi",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_names_oi)
+    .method("param_fnames_oi",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_fnames_oi)
+    .method("param_dims",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_dims)
+    .method("param_dims_oi",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_dims_oi)
+    .method("update_param_oi",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::update_param_oi)
     .method("param_oi_tidx",
             &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::param_oi_tidx)
-    .method("grad_log_prob", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::grad_log_prob) 
-    .method("log_prob", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::log_prob) 
-    .method("unconstrain_pars", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::unconstrain_pars) 
-    .method("constrain_pars", 
-            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::constrain_pars) 
-    .method("num_pars_unconstrained", 
+    .method("grad_log_prob",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::grad_log_prob)
+    .method("log_prob",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::log_prob)
+    .method("unconstrain_pars",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::unconstrain_pars)
+    .method("constrain_pars",
+            &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::constrain_pars)
+    .method("num_pars_unconstrained",
             &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::num_pars_unconstrained)
-    .method("unconstrained_param_names", 
+    .method("unconstrained_param_names",
             &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::unconstrained_param_names)
-    .method("constrained_param_names", 
+    .method("constrained_param_names",
             &rstan::stan_fit<%model_name%_namespace::%model_name%, boost::random::ecuyer1988>::constrained_param_names)
     ;
-} 
+}

--- a/rstan/rstan/inst/include/rstan/rstan_recorder.hpp
+++ b/rstan/rstan/inst/include/rstan/rstan_recorder.hpp
@@ -18,8 +18,8 @@ namespace rstan {
     FilteredValuesRecorder values_;
     FilteredValuesRecorder sampler_values_;
     SumValuesRecorder sum_;
-    
-    rstan_sample_recorder(CsvRecorder csv, FilteredValuesRecorder values, FilteredValuesRecorder sampler_values, SumValuesRecorder sum) 
+
+    rstan_sample_recorder(CsvRecorder csv, FilteredValuesRecorder values, FilteredValuesRecorder sampler_values, SumValuesRecorder sum)
       : csv_(csv), values_(values), sampler_values_(sampler_values), sum_(sum) { }
 
     void operator()(const std::vector<std::string>& x) {
@@ -28,7 +28,7 @@ namespace rstan {
       sampler_values_(x);
       sum_(x);
     }
-    
+
     template <class T>
     void operator()(const std::vector<T>& x) {
       csv_(x);
@@ -36,21 +36,21 @@ namespace rstan {
       sampler_values_(x);
       sum_(x);
     }
-    
-    void operator()(const std::string x) { 
+
+    void operator()(const std::string x) {
       csv_(x);
       values_(x);
       sampler_values_(x);
       sum_(x);
     }
-    
+
     void operator()() {
       csv_();
       values_();
       sampler_values_();
       sum_();
     }
-    
+
     bool is_recording() const {
       return csv_.is_recording() || values_.is_recording() || sampler_values_.is_recording() || sum_.is_recording();
     }
@@ -58,8 +58,8 @@ namespace rstan {
 
   /**
     @param      N
-    @param      M  number of iterations to be saved 
-    @param      warmup number of warmup iterations to be saved 
+    @param      M  number of iterations to be saved
+    @param      warmup number of warmup iterations to be saved
    */
 
   rstan_sample_recorder
@@ -69,23 +69,23 @@ namespace rstan {
                           const std::vector<size_t>& qoi_idx) {
     std::vector<size_t> filter(qoi_idx);
     std::vector<size_t> lp;
-    for (size_t n = 0; n < filter.size(); n++) 
+    for (size_t n = 0; n < filter.size(); n++)
       if (filter[n] >= N)
         lp.push_back(n);
     for (size_t n = 0; n < filter.size(); n++)
       filter[n] += offset;
     for (size_t n = 0; n < lp.size(); n++)
       filter[lp[n]] = 0;
-    
+
     std::vector<size_t> filter_sampler_values(offset);
     for (size_t n = 0; n < offset; n++)
       filter_sampler_values[n] = n;
-    
+
     stan::common::recorder::csv csv(o, prefix);
     stan::common::recorder::filtered_values<Rcpp::NumericVector> values(N, M, filter);
     stan::common::recorder::filtered_values<Rcpp::NumericVector> sampler_values(N, M, filter_sampler_values);
     stan::common::recorder::sum_values sum(N, warmup);
-    
+
     return rstan_sample_recorder(csv, values, sampler_values, sum);
   }
 

--- a/rstan/rstan/inst/include/rstan/rstaninc.hpp
+++ b/rstan/rstan/inst/include/rstan/rstaninc.hpp
@@ -1,5 +1,5 @@
 #ifndef __RSTAN__RSTANINC_HPP__
 #define __RSTAN__RSTANINC_HPP__
 #include <rstan/stan_fit.hpp>
-#endif 
+#endif
 

--- a/rstan/rstan/inst/include/rstan/stan_args.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_args.hpp
@@ -5,10 +5,10 @@
 
 #include <Rcpp.h>
 // #include <R.h>
-// #include <Rinternals.h> 
+// #include <Rinternals.h>
 
 #include <algorithm>
-#include <rstan/io/r_ostream.hpp> 
+#include <rstan/io/r_ostream.hpp>
 #include <stan/version.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -16,12 +16,12 @@ namespace rstan {
 
   namespace {
     /*
-     * Get an element of Rcpp::List by name. If not found, set it to a 
+     * Get an element of Rcpp::List by name. If not found, set it to a
      * default value.
-     * @param lst The list to look for elements 
+     * @param lst The list to look for elements
      * @param n The name of an element of interest
      * @param t Where to save the element
-     * @param v0 The default value if not found in the list 
+     * @param v0 The default value if not found in the list
      */
     template <class T>
     bool get_rlist_element(const Rcpp::List& lst, const char* n, T& t, const T& v0) {
@@ -45,39 +45,39 @@ namespace rstan {
       return b;
     }
 
-    inline unsigned int sexp2seed(SEXP seed) { 
-      if (TYPEOF(seed) == STRSXP)  
+    inline unsigned int sexp2seed(SEXP seed) {
+      if (TYPEOF(seed) == STRSXP)
         return boost::lexical_cast<unsigned int>(Rcpp::as<std::string>(seed));
-      return Rcpp::as<unsigned int>(seed); 
+      return Rcpp::as<unsigned int>(seed);
     }
 
     void write_comment(std::ostream& o) {
       o << "#" << std::endl;
     }
-  
+
     template <typename M>
     void write_comment(std::ostream& o, const M& msg) {
       o << "# " << msg << std::endl;
     }
-  
+
     template <typename K, typename V>
     void write_comment_property(std::ostream& o, const K& key, const V& val) {
       o << "# " << key << "=" << val << std::endl;
     }
 
-    /** 
-     * Find the index of an element in a vector. 
-     * @param v the vector in which an element are searched. 
-     * @param e the element that we are looking for. 
+    /**
+     * Find the index of an element in a vector.
+     * @param v the vector in which an element are searched.
+     * @param e the element that we are looking for.
      * @return If e is in v, return the index (0 to size - 1);
-     *  otherwise, return the size. 
+     *  otherwise, return the size.
      */
-   
+
     template <class T, class T2>
     size_t find_index(const std::vector<T>& v, const T2& e) {
-      return std::distance(v.begin(), std::find(v.begin(), v.end(), T(e)));  
-    } 
-  } 
+      return std::distance(v.begin(), std::find(v.begin(), v.end(), T(e)));
+    }
+  }
 
   enum sampling_algo_t { NUTS = 1, HMC = 2, Metropolis = 3, Fixed_param = 4};
   enum optim_algo_t { Newton = 1, BFGS = 3, LBFGS = 4};
@@ -86,31 +86,31 @@ namespace rstan {
 
   /**
    *
-   */ 
+   */
   class stan_args {
   private:
-    unsigned int random_seed; 
-    unsigned int chain_id; 
-    std::string init; 
-    SEXP init_list;  
+    unsigned int random_seed;
+    unsigned int chain_id;
+    std::string init;
+    SEXP init_list;
     double init_radius;
     std::string sample_file; // the file for outputting the samples
-    bool append_samples; 
-    bool sample_file_flag; // true: write out to a file; false, do not 
-    stan_args_method_t method; 
-    std::string diagnostic_file; 
+    bool append_samples;
+    bool sample_file_flag; // true: write out to a file; false, do not
+    stan_args_method_t method;
+    std::string diagnostic_file;
     bool diagnostic_file_flag;
     union {
       struct {
         int iter;   // number of iterations
-        int refresh;  // 
+        int refresh;  //
         sampling_algo_t algorithm;
         int warmup; // number of warmup
-        int thin; 
+        int thin;
         bool save_warmup; // weather to save warmup samples (always true now)
-        int iter_save; // number of iterations saved 
+        int iter_save; // number of iterations saved
         int iter_save_wo_warmup; // number of iterations saved wo warmup
-        bool adapt_engaged; 
+        bool adapt_engaged;
         double adapt_gamma;
         double adapt_delta;
         double adapt_kappa;
@@ -120,8 +120,8 @@ namespace rstan {
         double adapt_t0;
         sampling_metric_t metric; // UNIT_E, DIAG_E, DENSE_E;
         double stepsize; // defaut to 1;
-        double stepsize_jitter; 
-        int max_treedepth; // for NUTS, default to 10.  
+        double stepsize_jitter;
+        int max_treedepth; // for NUTS, default to 10.
         double int_time; // for HMC, default to 2 * pi
       } sampling;
       struct {
@@ -136,12 +136,12 @@ namespace rstan {
         double tol_rel_obj; // default to 1e4, for (L)BFGS
         double tol_rel_grad; // default to 1e7, for (L)BFGS
         int history_size; // default to 5, for LBFGS only
-      } optim; 
+      } optim;
       struct {
-        double epsilon; // default to 1e-6, for test_grad 
-        double error;  // default to 1e-6, for test_grad 
+        double epsilon; // default to 1e-6, for test_grad
+        double error;  // default to 1e-6, for test_grad
       } test_grad;
-    } ctrl; 
+    } ctrl;
 
   private:
     void validate_args() {
@@ -150,11 +150,11 @@ namespace rstan {
         msg << "Invalid value for parameter init_r (found "
             << init_radius << "; require >= 0).";
         throw std::invalid_argument(msg.str());
-      } 
+      }
       switch (method) {
-        case SAMPLING: 
+        case SAMPLING:
           if (ctrl.sampling.adapt_gamma < 0) {
-            std::stringstream msg; 
+            std::stringstream msg;
             msg << "Invalid adaptation parameter (found gamma="
                 << ctrl.sampling.adapt_gamma << "; require >0).";
             throw std::invalid_argument(msg.str());
@@ -164,7 +164,7 @@ namespace rstan {
             msg << "Invalid adaptation parameter (found detal="
                 << ctrl.sampling.adapt_delta << "; require 0<delta<1).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           if (ctrl.sampling.adapt_kappa < 0) {
             std::stringstream msg;
             msg << "Invalid adaptation parameter (found kappa="
@@ -177,41 +177,41 @@ namespace rstan {
                 << ctrl.sampling.adapt_t0 << "; require >0).";
             throw std::invalid_argument(msg.str());
           }
-          if (ctrl.sampling.stepsize < 0) {  
+          if (ctrl.sampling.stepsize < 0) {
             std::stringstream msg;
             msg << "Invalid adaptation parameter (found stepsize="
                 << ctrl.sampling.stepsize << "; require stepsize > 0).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           if (ctrl.sampling.stepsize_jitter < 0 || ctrl.sampling.stepsize_jitter > 1) {
             std::stringstream msg;
             msg << "Invalid adaptation parameter (found stepsize_jitter="
                 << ctrl.sampling.stepsize_jitter << "; require 0<=stepsize_jitter<=1).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           if (ctrl.sampling.algorithm == NUTS && ctrl.sampling.max_treedepth < 0) {
             std::stringstream msg;
             msg << "Invalid adaptation parameter (found max_treedepth="
                 << ctrl.sampling.max_treedepth << "; require max_treedepth>0).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           if (ctrl.sampling.algorithm == HMC && ctrl.sampling.int_time < 0) {
             std::stringstream msg;
             msg << "Invalid adaptation parameter (found int_time="
                 << ctrl.sampling.int_time << "; require int_time>0).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           break;
         case OPTIM:
-          if (ctrl.optim.init_alpha < 0) {  
-            std::stringstream msg; 
+          if (ctrl.optim.init_alpha < 0) {
+            std::stringstream msg;
             msg << "Invalid adaptation parameter (found init_alpha="
                 << ctrl.optim.init_alpha << "; require init_alpha > 0).";
             throw std::invalid_argument(msg.str());
-          } 
+          }
           break;
         case TEST_GRADIENT: break;
-      } 
+      }
     }
 
   public:
@@ -224,12 +224,12 @@ namespace rstan {
       get_rlist_element(in, "append_samples", append_samples, false);
       b = get_rlist_element(in, "method", t_str);
       if (!b) method = SAMPLING;
-      else { 
+      else {
         if ("sampling" == t_str)  method = SAMPLING;
         else if ("optim" == t_str)  method = OPTIM;
         else if ("test_grad" == t_str)  method = TEST_GRADIENT;
         else method = SAMPLING;
-      } 
+      }
 
       sample_file_flag = get_rlist_element(in, "sample_file", sample_file);
       diagnostic_file_flag = get_rlist_element(in, "diagnostic_file", diagnostic_file);
@@ -241,25 +241,25 @@ namespace rstan {
       get_rlist_element(in, "control", t_sexp, R_NilValue);
       Rcpp::List ctrl_lst(t_sexp);
 
-      switch (method) { 
-        case SAMPLING: 
+      switch (method) {
+        case SAMPLING:
           get_rlist_element(in, "iter", ctrl.sampling.iter, 2000);
           get_rlist_element(in, "warmup", ctrl.sampling.warmup, ctrl.sampling.iter / 2);
-   
+
           calculated_thin = (ctrl.sampling.iter - ctrl.sampling.warmup) / 1000;
           if (calculated_thin < 1) calculated_thin = 1;
           get_rlist_element(in, "thin", ctrl.sampling.thin, calculated_thin);
-  
-          ctrl.sampling.iter_save_wo_warmup 
-            = 1 + (ctrl.sampling.iter - ctrl.sampling.warmup - 1) / ctrl.sampling.thin; 
-          ctrl.sampling.iter_save 
+
+          ctrl.sampling.iter_save_wo_warmup
+            = 1 + (ctrl.sampling.iter - ctrl.sampling.warmup - 1) / ctrl.sampling.thin;
+          ctrl.sampling.iter_save
             = ctrl.sampling.iter_save_wo_warmup
               + 1 + (ctrl.sampling.warmup - 1) / ctrl.sampling.thin;
-  
-          ctrl.sampling.refresh = (ctrl.sampling.iter >= 20) ? 
-                                  ctrl.sampling.iter / 10 : 1; 
+
+          ctrl.sampling.refresh = (ctrl.sampling.iter >= 20) ?
+                                  ctrl.sampling.iter / 10 : 1;
           get_rlist_element(in, "refresh", ctrl.sampling.refresh);
-  
+
           get_rlist_element(ctrl_lst, "adapt_engaged", ctrl.sampling.adapt_engaged, true);
           get_rlist_element(ctrl_lst, "adapt_gamma", ctrl.sampling.adapt_gamma, 0.05);
           get_rlist_element(ctrl_lst, "adapt_delta", ctrl.sampling.adapt_delta, 0.8);
@@ -284,23 +284,23 @@ namespace rstan {
               msg << "Invalid value for parameter algorithm (found "
                   << t_str << "; require HMC, Metropolis, Fixed_param, or NUTS).";
               throw std::invalid_argument(msg.str());
-            } 
+            }
           } else {
             ctrl.sampling.algorithm = NUTS;
           }
 
-          if (get_rlist_element(ctrl_lst, "metric", t_str)) { 
+          if (get_rlist_element(ctrl_lst, "metric", t_str)) {
             if ("unit_e" == t_str) ctrl.sampling.metric = UNIT_E;
             else if ("diag_e" == t_str) ctrl.sampling.metric = DIAG_E;
             else if ("dense_e" == t_str) ctrl.sampling.metric = DENSE_E;
           } else ctrl.sampling.metric = DIAG_E;
-    
-          switch (ctrl.sampling.algorithm) { 
-            case NUTS: 
+
+          switch (ctrl.sampling.algorithm) {
+            case NUTS:
               get_rlist_element(ctrl_lst, "max_treedepth", ctrl.sampling.max_treedepth, 10);
               break;
-             case HMC: 
-              get_rlist_element(ctrl_lst, "int_time", ctrl.sampling.int_time, 
+             case HMC:
+              get_rlist_element(ctrl_lst, "int_time", ctrl.sampling.int_time,
                                 6.283185307179586476925286766559005768e+00);
                break;
              case Metropolis: break;
@@ -308,7 +308,7 @@ namespace rstan {
           }
           break;
 
-        case OPTIM: 
+        case OPTIM:
           get_rlist_element(in, "iter", ctrl.optim.iter, 2000);
           if (get_rlist_element(in, "algorithm", t_str)) {
             if ("BFGS" == t_str)  ctrl.optim.algorithm = BFGS;
@@ -322,13 +322,13 @@ namespace rstan {
             }
           } else {
             ctrl.optim.algorithm = BFGS;
-          } 
-          
+          }
+
           if (!get_rlist_element(in, "refresh", ctrl.optim.refresh)) {
-            ctrl.optim.refresh = ctrl.optim.iter / 100; 
+            ctrl.optim.refresh = ctrl.optim.iter / 100;
             if (ctrl.optim.refresh < 1) ctrl.optim.refresh = 1;
-          } 
-  
+          }
+
           get_rlist_element(in, "init_alpha", ctrl.optim.init_alpha, 0.001);
           get_rlist_element(in, "tol_obj", ctrl.optim.tol_obj, 1e-12);
           get_rlist_element(in, "tol_grad", ctrl.optim.tol_grad, 1e-8);
@@ -343,45 +343,45 @@ namespace rstan {
           get_rlist_element(ctrl_lst, "epsilon", ctrl.test_grad.epsilon,1e-6);
           get_rlist_element(ctrl_lst, "error", ctrl.test_grad.error,1e-6);
           break;
-      } 
+      }
 
       if (get_rlist_element(in, "init", t_sexp)) {
         switch (TYPEOF(t_sexp)) {
-          case STRSXP: init = Rcpp::as<std::string>(t_sexp); break; 
-          case VECSXP: init = "user"; init_list = t_sexp; break; 
-          default: init = "random"; 
-        } 
-      } else { 
-        init = "random"; 
+          case STRSXP: init = Rcpp::as<std::string>(t_sexp); break;
+          case VECSXP: init = "user"; init_list = t_sexp; break;
+          default: init = "random";
+        }
+      } else {
+        init = "random";
       }
       get_rlist_element(in, "init_r", init_radius, 2.0);
       if (0 >= init_radius)  init = "0";
       validate_args();
-    } 
+    }
 
     /**
      * return all the arguments used as an R list
-     * @return An R list containing all the arguments for a chain. 
-     */ 
+     * @return An R list containing all the arguments for a chain.
+     */
     SEXP stan_args_to_rlist() const {
       std::map<std::string, SEXP> args;
       std::map<std::string, SEXP> ctrl_args;
-      std::stringstream ss; 
-      ss << random_seed; 
+      std::stringstream ss;
+      ss << random_seed;
       args["random_seed"] = Rcpp::wrap(ss.str());
       args["chain_id"] = Rcpp::wrap(chain_id);
       args["init"] = Rcpp::wrap(init);
       args["init_list"] = init_list;
       args["init_radius"] = Rcpp::wrap(init_radius);
       args["append_samples"] = Rcpp::wrap(append_samples);
-      if (sample_file_flag) 
+      if (sample_file_flag)
         args["sample_file"] = Rcpp::wrap(sample_file);
-      if (diagnostic_file_flag) 
+      if (diagnostic_file_flag)
         args["diagnostic_file_flag"] = Rcpp::wrap(diagnostic_file);
 
       std::string sampler_t;
-      switch (method) { 
-        case SAMPLING: 
+      switch (method) {
+        case SAMPLING:
           args["method"] = Rcpp::wrap("sampling");
           args["iter"] = Rcpp::wrap(ctrl.sampling.iter);
           args["warmup"] = Rcpp::wrap(ctrl.sampling.warmup);
@@ -398,31 +398,31 @@ namespace rstan {
           ctrl_args["adapt_window"] = Rcpp::wrap(ctrl.sampling.adapt_window);
           ctrl_args["stepsize"] = Rcpp::wrap(ctrl.sampling.stepsize);
           ctrl_args["stepsize_jitter"] = Rcpp::wrap(ctrl.sampling.stepsize_jitter);
-          switch (ctrl.sampling.algorithm) { 
-            case NUTS: 
+          switch (ctrl.sampling.algorithm) {
+            case NUTS:
               ctrl_args["max_treedepth"] = Rcpp::wrap(ctrl.sampling.max_treedepth);
               sampler_t.append("NUTS");
               break;
-            case HMC: 
+            case HMC:
               ctrl_args["int_time"] = Rcpp::wrap(ctrl.sampling.int_time);
               sampler_t.append("HMC");
               break;
-            case Metropolis: 
+            case Metropolis:
               sampler_t.append("Metropolis");
               break;
             default: break;
-          } 
-          if (ctrl.sampling.algorithm != Metropolis) { 
-            switch (ctrl.sampling.metric) { 
-              case UNIT_E: 
-                ctrl_args["metric"] = Rcpp::wrap("unit_e"); 
+          }
+          if (ctrl.sampling.algorithm != Metropolis) {
+            switch (ctrl.sampling.metric) {
+              case UNIT_E:
+                ctrl_args["metric"] = Rcpp::wrap("unit_e");
                 sampler_t.append("(unit_e)");
                 break;
-              case DIAG_E: 
+              case DIAG_E:
                 ctrl_args["metric"] = Rcpp::wrap("diag_e");
                 sampler_t.append("(diag_e)");
                 break;
-              case DENSE_E: 
+              case DENSE_E:
                 ctrl_args["metric"] = Rcpp::wrap("dense_e");
                 sampler_t.append("(dense_e)");
                 break;
@@ -431,14 +431,14 @@ namespace rstan {
           args["sampler_t"] = Rcpp::wrap(sampler_t);
           args["control"] = Rcpp::wrap(ctrl_args);
           break;
-        case OPTIM: 
+        case OPTIM:
           args["method"] = Rcpp::wrap("optim");
           args["iter"] = Rcpp::wrap(ctrl.optim.iter);
           args["refresh"] = Rcpp::wrap(ctrl.optim.refresh);
           args["save_iterations"] = Rcpp::wrap(ctrl.optim.save_iterations);
           switch (ctrl.optim.algorithm) {
             case Newton: args["algorithm"] = Rcpp::wrap("Newton"); break;
-            case LBFGS: args["algorithm"] = Rcpp::wrap("LBFGS"); 
+            case LBFGS: args["algorithm"] = Rcpp::wrap("LBFGS");
                         args["init_alpha"] = Rcpp::wrap(ctrl.optim.init_alpha);
                         args["tol_param"] = Rcpp::wrap(ctrl.optim.tol_param);
                         args["tol_obj"] = Rcpp::wrap(ctrl.optim.tol_obj);
@@ -447,7 +447,7 @@ namespace rstan {
                         args["tol_rel_grad"] = Rcpp::wrap(ctrl.optim.tol_rel_grad);
                         args["history_size"] = Rcpp::wrap(ctrl.optim.history_size);
                         break;
-            case BFGS: args["algorithm"] = Rcpp::wrap("BFGS"); 
+            case BFGS: args["algorithm"] = Rcpp::wrap("BFGS");
                        args["init_alpha"] = Rcpp::wrap(ctrl.optim.init_alpha);
                        args["tol_param"] = Rcpp::wrap(ctrl.optim.tol_param);
                        args["tol_obj"] = Rcpp::wrap(ctrl.optim.tol_obj);
@@ -455,7 +455,7 @@ namespace rstan {
                        args["tol_rel_obj"] = Rcpp::wrap(ctrl.optim.tol_rel_obj);
                        args["tol_rel_grad"] = Rcpp::wrap(ctrl.optim.tol_rel_grad);
                        break;
-          } 
+          }
           break;
         case TEST_GRADIENT:
           args["method"] = Rcpp::wrap("test_grad");
@@ -463,66 +463,66 @@ namespace rstan {
           ctrl_args["epsilon"] = Rcpp::wrap(ctrl.test_grad.epsilon);
           ctrl_args["error"] = Rcpp::wrap(ctrl.test_grad.error);
           args["control"] = Rcpp::wrap(ctrl_args);
-      } 
+      }
       return Rcpp::wrap(args);
-    } 
+    }
 
     inline const std::string& get_sample_file() const {
       return sample_file;
-    } 
-    inline bool get_sample_file_flag() const { 
-      return sample_file_flag; 
+    }
+    inline bool get_sample_file_flag() const {
+      return sample_file_flag;
     }
     inline bool get_diagnostic_file_flag() const {
       return diagnostic_file_flag;
-    } 
+    }
     inline const std::string& get_diagnostic_file() const {
       return diagnostic_file;
-    } 
+    }
 
     void set_random_seed(unsigned int seed) {
       random_seed = seed;
-    } 
+    }
 
     inline unsigned int get_random_seed() const {
-      return random_seed; 
-    } 
+      return random_seed;
+    }
 
-    inline int get_ctrl_sampling_refresh() const { 
-      return ctrl.sampling.refresh; 
-    } 
-    const inline sampling_metric_t get_ctrl_sampling_metric() const { 
+    inline int get_ctrl_sampling_refresh() const {
+      return ctrl.sampling.refresh;
+    }
+    const inline sampling_metric_t get_ctrl_sampling_metric() const {
       return ctrl.sampling.metric;
-    } 
+    }
     const inline sampling_algo_t get_ctrl_sampling_algorithm() const {
       return ctrl.sampling.algorithm;
     }
-    inline int get_ctrl_sampling_warmup() const { 
+    inline int get_ctrl_sampling_warmup() const {
       return ctrl.sampling.warmup;
-    } 
+    }
     void set_ctrl_sampling_warmup(int n) {
       ctrl.sampling.warmup = n;
     }
-    inline int get_ctrl_sampling_thin() const { 
-      return ctrl.sampling.thin; 
-    } 
+    inline int get_ctrl_sampling_thin() const {
+      return ctrl.sampling.thin;
+    }
     inline double get_ctrl_sampling_int_time() const {
       return ctrl.sampling.int_time;
     }
     inline bool get_append_samples() const {
       return append_samples;
-    } 
+    }
     inline stan_args_method_t get_method() const {
       return method;
-    } 
+    }
     inline int get_iter() const {
       switch (method) {
         case SAMPLING: return ctrl.sampling.iter;
         case OPTIM: return ctrl.optim.iter;
         case TEST_GRADIENT: return 0;
-      } 
+      }
       return 0;
-    } 
+    }
     inline bool get_ctrl_sampling_adapt_engaged() const {
       return ctrl.sampling.adapt_engaged;
     }
@@ -538,7 +538,7 @@ namespace rstan {
     inline double get_ctrl_sampling_adapt_t0() const {
       return ctrl.sampling.adapt_t0;
     }
-    inline unsigned int get_ctrl_sampling_adapt_init_buffer() const { 
+    inline unsigned int get_ctrl_sampling_adapt_init_buffer() const {
       return ctrl.sampling.adapt_init_buffer;
     }
     inline unsigned int get_ctrl_sampling_adapt_term_buffer() const {
@@ -549,32 +549,32 @@ namespace rstan {
     }
     inline double get_ctrl_sampling_stepsize() const {
        return ctrl.sampling.stepsize;
-    } 
+    }
     inline double get_ctrl_sampling_stepsize_jitter() const {
        return ctrl.sampling.stepsize_jitter;
-    } 
+    }
     inline int get_ctrl_sampling_max_treedepth() const {
        return ctrl.sampling.max_treedepth;
-    } 
+    }
     inline int get_ctrl_sampling_iter_save_wo_warmup() const {
-       return ctrl.sampling.iter_save_wo_warmup; 
-    } 
+       return ctrl.sampling.iter_save_wo_warmup;
+    }
     inline int get_ctrl_sampling_iter_save() const {
-       return ctrl.sampling.iter_save; 
-    } 
+       return ctrl.sampling.iter_save;
+    }
     inline bool get_ctrl_sampling_save_warmup() const {
        return true;
     }
     inline optim_algo_t get_ctrl_optim_algorithm() const {
       return ctrl.optim.algorithm;
-    } 
+    }
     inline int get_ctrl_optim_refresh() const {
       return ctrl.optim.refresh;
-    } 
+    }
     inline bool get_ctrl_optim_save_iterations() const {
       return ctrl.optim.save_iterations;
     }
-    inline double get_ctrl_optim_init_alpha() const { 
+    inline double get_ctrl_optim_init_alpha() const {
       return ctrl.optim.init_alpha;
     }
     inline double get_ctrl_optim_tol_obj() const {
@@ -592,9 +592,9 @@ namespace rstan {
     inline double get_ctrl_optim_tol_rel_grad() const {
       return ctrl.optim.tol_rel_grad;
     }
-    inline int get_ctrl_optim_history_size() const { 
+    inline int get_ctrl_optim_history_size() const {
       return ctrl.optim.history_size;
-    } 
+    }
     inline double get_ctrl_test_grad_epsilon() const {
       return ctrl.test_grad.epsilon;
     }
@@ -603,25 +603,25 @@ namespace rstan {
     }
     inline unsigned int get_chain_id() const {
       return chain_id;
-    } 
+    }
     inline double get_init_radius() const {
       return init_radius;
-    } 
+    }
     const std::string& get_init() const {
       return init;
-    } 
+    }
     SEXP get_init_list() const {
-      return init_list; 
-    } 
+      return init_list;
+    }
 
 
-    void write_args_as_comment(std::ostream& ostream) const { 
+    void write_args_as_comment(std::ostream& ostream) const {
       write_comment_property(ostream,"init",init);
       write_comment_property(ostream,"seed",random_seed);
       write_comment_property(ostream,"chain_id",chain_id);
-      write_comment_property(ostream,"iter",get_iter()); 
+      write_comment_property(ostream,"iter",get_iter());
       switch (method) {
-        case SAMPLING: 
+        case SAMPLING:
           write_comment_property(ostream,"warmup",ctrl.sampling.warmup);
           write_comment_property(ostream,"save_warmup",1);
           write_comment_property(ostream,"thin",ctrl.sampling.thin);
@@ -634,24 +634,24 @@ namespace rstan {
           write_comment_property(ostream,"adapt_kappa",ctrl.sampling.adapt_kappa);
           write_comment_property(ostream,"adapt_t0",ctrl.sampling.adapt_t0);
           switch (ctrl.sampling.algorithm) {
-            case NUTS: 
+            case NUTS:
               write_comment_property(ostream,"max_treedepth",ctrl.sampling.max_treedepth);
               switch (ctrl.sampling.metric) {
                 case UNIT_E: write_comment_property(ostream,"sampler_t","NUTS(unit_e)"); break;
                 case DIAG_E: write_comment_property(ostream,"sampler_t","NUTS(diag_e)"); break;
                 case DENSE_E: write_comment_property(ostream,"sampler_t","NUTS(dense_e)"); break;
-              } 
+              }
               break;
             case HMC: write_comment_property(ostream,"sampler_t", "HMC");
-                      write_comment_property(ostream,"int_time", ctrl.sampling.int_time); 
+                      write_comment_property(ostream,"int_time", ctrl.sampling.int_time);
                       break;
             case Metropolis: write_comment_property(ostream,"sampler_t", "Metropolis"); break;
             case Fixed_param: write_comment_property(ostream, "sampler_t", "Fixed_param"); break;
             default: break;
-          } 
+          }
           break;
 
-        case OPTIM: 
+        case OPTIM:
           write_comment_property(ostream,"refresh",ctrl.optim.refresh);
           write_comment_property(ostream,"save_iterations",ctrl.optim.save_iterations);
           switch (ctrl.optim.algorithm) {
@@ -673,18 +673,18 @@ namespace rstan {
                        write_comment_property(ostream,"tol_rel_grad", ctrl.optim.tol_rel_grad);
                        write_comment_property(ostream,"history_size", ctrl.optim.history_size);
                        break;
-          } 
+          }
         case TEST_GRADIENT: break;
-      } 
-      if (sample_file_flag) 
+      }
+      if (sample_file_flag)
         write_comment_property(ostream,"sample_file",sample_file);
       if (diagnostic_file_flag)
         write_comment_property(ostream,"diagnostic_file",diagnostic_file);
       write_comment_property(ostream,"append_samples",append_samples);
       write_comment(ostream);
     }
-  }; 
-} 
+  };
+}
 
-#endif 
+#endif
 

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -35,9 +35,9 @@
 #include <stan/common/print_progress.hpp>
 
 
-#include <rstan/io/rlist_ref_var_context.hpp> 
-#include <rstan/io/r_ostream.hpp> 
-#include <rstan/stan_args.hpp> 
+#include <rstan/io/rlist_ref_var_context.hpp>
+#include <rstan/io/r_ostream.hpp>
+#include <rstan/stan_args.hpp>
 // #include <stan/mcmc/chains.hpp>
 #include <Rcpp.h>
 // #include <Rinternals.h>
@@ -47,7 +47,7 @@
 // void R_CheckUserInterrupt(void);
 
 
-// REF: stan/common/command.hpp 
+// REF: stan/common/command.hpp
 
 #include <stan/io/mcmc_writer.hpp>
 #include <stan/common/recorder/messages.hpp>
@@ -62,10 +62,10 @@ namespace rstan {
      *@tparam T The type by which we use for dimensions. T could be say size_t
      * or unsigned int. This whole business (not using size_t) is due to that
      * Rcpp::wrap/as does not support size_t on some platforms and R could not
-     * deal with 64bits integers. 
+     * deal with 64bits integers.
      *
-     */ 
-    template <class T> 
+     */
+    template <class T>
     size_t calc_num_params(const std::vector<T>& dim) {
       T num_params = 1;
       for (size_t i = 0;  i < dim.size(); ++i)
@@ -73,16 +73,16 @@ namespace rstan {
       return num_params;
     }
 
-    template <class T> 
+    template <class T>
     void calc_starts(const std::vector<std::vector<T> >& dims,
-                     std::vector<T>& starts) { 
-      starts.resize(0); 
-      starts.push_back(0); 
+                     std::vector<T>& starts) {
+      starts.resize(0);
+      starts.push_back(0);
       for (size_t i = 1; i < dims.size(); ++i)
         starts.push_back(starts[i - 1] + calc_num_params(dims[i - 1]));
     }
 
-    template <class T> 
+    template <class T>
     T calc_total_num_params(const std::vector<std::vector<T> >& dims) {
       T num_params = 0;
       for (size_t i = 0; i < dims.size(); ++i)
@@ -92,25 +92,25 @@ namespace rstan {
 
     /**
      *  Get the parameter indexes for a vector(array) parameter.
-     *  For example, we have parameter beta, which has 
-     *  dimension [2,3]. Then this function gets 
+     *  For example, we have parameter beta, which has
+     *  dimension [2,3]. Then this function gets
      *  the indexes as (if col_major = false)
-     *  [0,0], [0,1], [0,2] 
-     *  [1,0], [1,1], [1,2] 
-     *  or (if col_major = true) 
-     *  [0,0], [1,0] 
-     *  [0,1], [1,1] 
-     *  [0,2], [121] 
+     *  [0,0], [0,1], [0,2]
+     *  [1,0], [1,1], [1,2]
+     *  or (if col_major = true)
+     *  [0,0], [1,0]
+     *  [0,1], [1,1]
+     *  [0,2], [121]
      *
      *  @param dim[in] the dimension of parameter
      *  @param idx[out] for keeping all the indexes
      *
-     *  <p> when idx is empty (size = 0), idx 
-     *  would contains an empty vector. 
-     * 
+     *  <p> when idx is empty (size = 0), idx
+     *  would contains an empty vector.
+     *
      *
      */
-    
+
     template <class T>
     void expand_indices(std::vector<T> dim,
                         std::vector<std::vector<T> >& idx,
@@ -122,11 +122,11 @@ namespace rstan {
       std::vector<size_t> loopj;
       for (size_t i = 1; i <= len; ++i)
         loopj.push_back(len - i);
-    
+
       if (col_major)
         for (size_t i = 0; i < len; ++i)
           loopj[i] = len - 1 - loopj[i];
-    
+
       idx.push_back(std::vector<T>(len, 0));
       for (size_t i = 1; i < total; i++) {
         std::vector<T>  v(idx.back());
@@ -143,8 +143,8 @@ namespace rstan {
     }
 
     /**
-     * Get the names for an array of given dimensions 
-     * in the way of column majored. 
+     * Get the names for an array of given dimensions
+     * in the way of column majored.
      * For example, if we know an array named `a`, with
      * dimensions of [2, 3, 4], the names then are (starting
      * from 0):
@@ -173,10 +173,10 @@ namespace rstan {
      * a[0,2,3]
      * a[1,2,3]
      *
-     * @param name The name of the array variable 
-     * @param dim The dimensions of the array 
-     * @param fnames[out] Where the names would be pushed. 
-     * @param first_is_one[true] Where to start for the first index: 0 or 1. 
+     * @param name The name of the array variable
+     * @param dim The dimensions of the array
+     * @param fnames[out] Where the names would be pushed.
+     * @param first_is_one[true] Where to start for the first index: 0 or 1.
      *
      */
     template <class T> void
@@ -186,14 +186,14 @@ namespace rstan {
                   bool col_major = true,
                   bool first_is_one = true) {
 
-      fnames.clear(); 
+      fnames.clear();
       if (0 == dim.size()) {
         fnames.push_back(name);
         return;
       }
 
       std::vector<std::vector<T> > idx;
-      expand_indices(dim, idx, col_major); 
+      expand_indices(dim, idx, col_major);
       size_t first = first_is_one ? 1 : 0;
       for (typename std::vector<std::vector<T> >::const_iterator it = idx.begin();
            it != idx.end();
@@ -209,48 +209,48 @@ namespace rstan {
       }
     }
 
-    // vectorize get_flatnames 
-    template <class T> 
-    void get_all_flatnames(const std::vector<std::string>& names, 
-                           const std::vector<T>& dims, 
-                           std::vector<std::string>& fnames, 
+    // vectorize get_flatnames
+    template <class T>
+    void get_all_flatnames(const std::vector<std::string>& names,
+                           const std::vector<T>& dims,
+                           std::vector<std::string>& fnames,
                            bool col_major = true) {
-      fnames.clear(); 
+      fnames.clear();
       for (size_t i = 0; i < names.size(); ++i) {
-        std::vector<std::string> i_names; 
+        std::vector<std::string> i_names;
         get_flatnames(names[i], dims[i], i_names, col_major, true); // col_major = true
         fnames.insert(fnames.end(), i_names.begin(), i_names.end());
-      } 
-    } 
+      }
+    }
 
     /* To facilitate transform an array variable ordered by col-major index
      * to row-major index order by providing the transforming indices.
      * For example, we have "x[2,3]", then if ordered by col-major, we have
-     * 
+     *
      * x[1,1], x[2,1], x[1,2], x[2,2], x[1,3], x[3,1]
-     * 
-     * Then the indices for transforming to row-major order are 
-     * [0, 2, 4, 1, 3, 5] + start. 
+     *
+     * Then the indices for transforming to row-major order are
+     * [0, 2, 4, 1, 3, 5] + start.
      *
      * @param dim[in] the dimension of the array variable, empty means a scalar
      * @param midx[out] store the indices for mapping col-major to row-major
      * @param start shifts the indices with a starting point
      *
-     */ 
+     */
     template <typename T, typename T2>
     void get_indices_col2row(const std::vector<T>& dim, std::vector<T2>& midx,
                              T start = 0) {
       size_t len = dim.size();
-      if (len < 1) { 
-        midx.push_back(start); 
-        return; 
+      if (len < 1) {
+        midx.push_back(start);
+        return;
       }
-    
+
       std::vector<T> z(len, 1);
       for (size_t i = 1; i < len; i++) {
         z[i] *= z[i - 1] * dim[i - 1];
-      } 
-    
+      }
+
       T total = calc_num_params(dim);
       midx.resize(total);
       std::fill_n(midx.begin(), total, start);
@@ -260,43 +260,43 @@ namespace rstan {
           size_t k = len - j - 1;
           if (v[k] < dim[k] - 1) {
             v[k] += 1;
-            break; 
+            break;
           }
-          v[k] = 0; 
-        } 
-        // v is the index of the ith element by row-major, for example v=[0,1,2]. 
-        // obtain the position for v if it is col-major indexed. 
+          v[k] = 0;
+        }
+        // v is the index of the ith element by row-major, for example v=[0,1,2].
+        // obtain the position for v if it is col-major indexed.
         T pos = 0;
-        for (size_t j = 0; j < len; j++) 
+        for (size_t j = 0; j < len; j++)
           pos += z[j] * v[j];
         midx[i] += pos;
-      } 
-    } 
-   
+      }
+    }
+
     template <class T>
     void get_all_indices_col2row(const std::vector<std::vector<T> >& dims,
                                  std::vector<size_t>& midx) {
       midx.clear();
-      std::vector<T> starts; 
+      std::vector<T> starts;
       calc_starts(dims, starts);
       for (size_t i = 0; i < dims.size(); ++i) {
         std::vector<size_t> midxi;
         get_indices_col2row(dims[i], midxi, starts[i]);
         midx.insert(midx.end(), midxi.begin(), midxi.end());
-      } 
-    } 
-    
+      }
+    }
+
     template <class Model>
-    std::vector<std::string> get_param_names(Model& m) { 
+    std::vector<std::string> get_param_names(Model& m) {
       std::vector<std::string> names;
       m.get_param_names(names);
       names.push_back("lp__");
-      return names; 
+      return names;
     }
 
     template <class T>
-    void print_vector(const std::vector<T>& v, std::ostream& o, 
-                      const std::vector<size_t>& midx, 
+    void print_vector(const std::vector<T>& v, std::ostream& o,
+                      const std::vector<size_t>& midx,
                       const std::string& sep = ",") {
       if (v.size() > 0)
         o << v[0];
@@ -306,7 +306,7 @@ namespace rstan {
     }
 
     template <class T>
-    void print_vector(const std::vector<T>& v, std::ostream& o, 
+    void print_vector(const std::vector<T>& v, std::ostream& o,
                       const std::string& sep = ",") {
       if (v.size() > 0)
         o << v[0];
@@ -316,35 +316,35 @@ namespace rstan {
     }
 
     /**
-     * Cast a size_t vector to an unsigned int vector. 
-     * The reason is that first Rcpp::wrap/as does not 
-     * support size_t on some platforms; second R 
-     * could not deal with 64bits integers.  
-     */ 
+     * Cast a size_t vector to an unsigned int vector.
+     * The reason is that first Rcpp::wrap/as does not
+     * support size_t on some platforms; second R
+     * could not deal with 64bits integers.
+     */
 
-    std::vector<unsigned int> 
+    std::vector<unsigned int>
     sizet_to_uint(std::vector<size_t> v1) {
       std::vector<unsigned int> v2(v1.size());
-      for (size_t i = 0; i < v1.size(); ++i) 
+      for (size_t i = 0; i < v1.size(); ++i)
         v2[i] = static_cast<unsigned int>(v1[i]);
       return v2;
-    } 
+    }
 
     template <class Model>
     std::vector<std::vector<unsigned int> > get_param_dims(Model& m) {
-      std::vector<std::vector<size_t> > dims; 
-      m.get_dims(dims); 
+      std::vector<std::vector<size_t> > dims;
+      m.get_dims(dims);
 
-      std::vector<std::vector<unsigned int> > uintdims; 
+      std::vector<std::vector<unsigned int> > uintdims;
       for (std::vector<std::vector<size_t> >::const_iterator it = dims.begin();
-           it != dims.end(); 
-           ++it) 
-        uintdims.push_back(sizet_to_uint(*it)); 
+           it != dims.end();
+           ++it)
+        uintdims.push_back(sizet_to_uint(*it));
 
       std::vector<unsigned int> scalar_dim; // for lp__
-      uintdims.push_back(scalar_dim); 
-      return uintdims; 
-    } 
+      uintdims.push_back(scalar_dim);
+      return uintdims;
+    }
 
     template<class Sampler>
     void init_static_hmc(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args) {
@@ -352,10 +352,10 @@ namespace rstan {
       double epsilon_jitter = args.get_ctrl_sampling_stepsize_jitter();
       double int_time = args.get_ctrl_sampling_int_time();
 
-      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr); 
+      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr);
       sampler_ptr2->set_nominal_stepsize_and_T(epsilon, int_time);
       sampler_ptr2->set_stepsize_jitter(epsilon_jitter);
-    } 
+    }
 
     template<class Sampler>
     void init_nuts(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args) {
@@ -363,14 +363,14 @@ namespace rstan {
       double epsilon_jitter = args.get_ctrl_sampling_stepsize_jitter();
       int max_depth = args.get_ctrl_sampling_max_treedepth();
 
-      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr); 
+      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr);
       sampler_ptr2->set_nominal_stepsize(epsilon);
       sampler_ptr2->set_stepsize_jitter(epsilon_jitter);
       sampler_ptr2->set_max_depth(max_depth);
     }
-    
+
     template<class Sampler>
-    void init_adapt(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args, 
+    void init_adapt(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args,
                     const Eigen::VectorXd& cont_params) {
 
       if (!args.get_ctrl_sampling_adapt_engaged()) return;
@@ -381,7 +381,7 @@ namespace rstan {
       double t0 = args.get_ctrl_sampling_adapt_t0();
       double epsilon = args.get_ctrl_sampling_stepsize();
 
-      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr); 
+      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr);
       sampler_ptr2->get_stepsize_adaptation().set_mu(log(10 * epsilon));
       sampler_ptr2->get_stepsize_adaptation().set_delta(delta);
       sampler_ptr2->get_stepsize_adaptation().set_gamma(gamma);
@@ -393,11 +393,11 @@ namespace rstan {
     }
 
     template<class Sampler>
-    bool init_windowed_adapt(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args, 
+    bool init_windowed_adapt(stan::mcmc::base_mcmc* sampler_ptr, const stan_args& args,
                              const Eigen::VectorXd& cont_params) {
- 
+
       init_adapt<Sampler>(sampler_ptr, args, cont_params);
-      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr); 
+      Sampler* sampler_ptr2 = dynamic_cast<Sampler*>(sampler_ptr);
       sampler_ptr2->set_window_params(args.get_ctrl_sampling_warmup(),
                                       args.get_ctrl_sampling_adapt_init_buffer(),
                                       args.get_ctrl_sampling_adapt_term_buffer(),
@@ -406,7 +406,7 @@ namespace rstan {
     }
 
     struct R_CheckUserInterrupt_Functor {
-      void operator()() { 
+      void operator()() {
         R_CheckUserInterrupt();
       }
     };
@@ -425,31 +425,31 @@ namespace rstan {
                          std::vector<std::string>& model_unconstrained_param_names,
                          std::vector<std::string>& sampler_diagnostic_names) {
       s.get_sample_param_names(sample_names);
-      
+
       sampler_ptr->get_sampler_param_names(sampler_names);
-      
+
       model.constrained_param_names(model_constrained_param_names, true, true);
-      
+
       model.unconstrained_param_names(model_unconstrained_param_names, false, false);
-      
-      sampler_ptr->get_sampler_diagnostic_names(model_unconstrained_param_names, 
+
+      sampler_ptr->get_sampler_diagnostic_names(model_unconstrained_param_names,
                                                 sampler_diagnostic_names);
 
-      sample_recorder_size = sample_names.size() + sampler_names.size() 
+      sample_recorder_size = sample_names.size() + sampler_names.size()
         + model_constrained_param_names.size();
       sample_recorder_offset = sample_names.size() + sampler_names.size();
     }
 
 
-    template <class Model, class RNG_t> 
+    template <class Model, class RNG_t>
     void execute_sampling(stan_args& args, Model& model, Rcpp::List& holder,
-                          stan::mcmc::base_mcmc* sampler_ptr, 
+                          stan::mcmc::base_mcmc* sampler_ptr,
                           stan::mcmc::sample& s,
-                          const std::vector<size_t>& qoi_idx, 
+                          const std::vector<size_t>& qoi_idx,
                           std::vector<double>& initv,
                           std::fstream& sample_stream,
                           std::fstream& diagnostic_stream,
-                          const std::vector<std::string>& fnames_oi, RNG_t& base_rng) {  
+                          const std::vector<std::string>& fnames_oi, RNG_t& base_rng) {
       size_t sample_recorder_size, sample_recorder_offset;
       std::vector<std::string> sample_names;
       std::vector<std::string> sampler_names;
@@ -457,23 +457,23 @@ namespace rstan {
       std::vector<std::string> model_unconstrained_param_names;
       std::vector<std::string> sampler_diagnostic_names;
       rstan::calculate_sizes(model, s, sampler_ptr,
-                             sample_recorder_size, 
-                             sample_recorder_offset, 
+                             sample_recorder_size,
+                             sample_recorder_offset,
                              sample_names,
                              sampler_names,
                              model_constrained_param_names,
                              model_unconstrained_param_names,
                              sampler_diagnostic_names);
-      
-      
+
+
       rstan_sample_recorder sample_recorder
         = sample_recorder_factory(&sample_stream, "# ",
                                   sample_recorder_size,
-                                  args.get_ctrl_sampling_iter_save(), 
+                                  args.get_ctrl_sampling_iter_save(),
                                   args.get_ctrl_sampling_iter_save() - args.get_ctrl_sampling_iter_save_wo_warmup(),
                                   sample_recorder_offset,
                                   qoi_idx);
-      
+
       stan::common::recorder::csv diagnostic_recorder
         = diagnostic_recorder_factory(&diagnostic_stream, "# ");
 
@@ -483,29 +483,29 @@ namespace rstan {
                             rstan_sample_recorder, stan::common::recorder::csv,
                             stan::common::recorder::messages>
         writer(sample_recorder, diagnostic_recorder, message_recorder, &Rcpp::Rcout);
-      
+
       if (!args.get_append_samples()) {
         writer.write_sample_names(s, sampler_ptr, model);
         writer.write_diagnostic_names(s, sampler_ptr, model);
       }
-      
+
       // Warm-Up
       clock_t start = clock();
-        
+
       std::string prefix = "\n";
       std::string suffix = "";
       R_CheckUserInterrupt_Functor interruptCallback;
-        
+
       stan::common::warmup<Model, RNG_t,
                            R_CheckUserInterrupt_Functor>
-        (sampler_ptr, args.get_ctrl_sampling_warmup(), args.get_iter() - args.get_ctrl_sampling_warmup(), 
+        (sampler_ptr, args.get_ctrl_sampling_warmup(), args.get_iter() - args.get_ctrl_sampling_warmup(),
          args.get_ctrl_sampling_thin(),
          args.get_ctrl_sampling_refresh(), args.get_ctrl_sampling_save_warmup(),
          writer,
          s, model, base_rng,
          prefix, suffix, Rcpp::Rcout,
          interruptCallback);
-        
+
       clock_t end = clock();
       double warmDeltaT = (double)(end - start) / CLOCKS_PER_SEC;
       std::string adaptation_info;
@@ -522,23 +522,23 @@ namespace rstan {
 
       // Sampling
       start = clock();
-        
+
       stan::common::sample<Model, RNG_t,
                            R_CheckUserInterrupt_Functor>
-        (sampler_ptr, args.get_ctrl_sampling_warmup(), args.get_iter() - args.get_ctrl_sampling_warmup(), 
+        (sampler_ptr, args.get_ctrl_sampling_warmup(), args.get_iter() - args.get_ctrl_sampling_warmup(),
          args.get_ctrl_sampling_thin(),
          args.get_ctrl_sampling_refresh(), true,
          writer,
          s, model, base_rng,
          prefix, suffix, Rcpp::Rcout,
          interruptCallback);
-        
+
       end = clock();
-      double sampleDeltaT = (double)(end - start) / CLOCKS_PER_SEC;        
-      
+      double sampleDeltaT = (double)(end - start) / CLOCKS_PER_SEC;
+
       writer.write_timing(warmDeltaT, sampleDeltaT);
-      
-      
+
+
 
       double mean_lp(0);
       std::vector<double> mean_pars;
@@ -551,24 +551,24 @@ namespace rstan {
           mean_pars[n] = sample_recorder.sum_.sum()[sample_recorder_offset + n] * inverse_saved;
         }
       }
-      
+
       if (args.get_sample_file_flag()) {
-        rstan::io::rcout << "Sample of chain " 
-                         << args.get_chain_id() 
+        rstan::io::rcout << "Sample of chain "
+                         << args.get_chain_id()
                          << " is written to file " << args.get_sample_file() << "."
                          << std::endl;
         sample_stream.close();
       }
-      if (args.get_diagnostic_file_flag()) 
+      if (args.get_diagnostic_file_flag())
         diagnostic_stream.close();
-        
-      holder = Rcpp::List(sample_recorder.values_.x().begin(), 
+
+      holder = Rcpp::List(sample_recorder.values_.x().begin(),
                           sample_recorder.values_.x().end());
-      holder.attr("test_grad") = Rcpp::wrap(false); 
-      holder.attr("args") = args.stan_args_to_rlist(); 
-      holder.attr("inits") = initv; 
-      holder.attr("mean_pars") = mean_pars; 
-      holder.attr("mean_lp__") = mean_lp; 
+      holder.attr("test_grad") = Rcpp::wrap(false);
+      holder.attr("args") = args.stan_args_to_rlist();
+      holder.attr("inits") = initv;
+      holder.attr("mean_pars") = mean_pars;
+      holder.attr("mean_lp__") = mean_lp;
       holder.attr("adaptation_info") = adaptation_info;
 
       Rcpp::List slst(sample_recorder.sampler_values_.x().begin()+1,
@@ -579,32 +579,32 @@ namespace rstan {
       holder.attr("sampler_params") = slst;
 
       holder.names() = fnames_oi;
-    } 
+    }
 
 
     /**
-     * @tparam Model 
-     * @tparam RNG 
+     * @tparam Model
+     * @tparam RNG
      *
      * @param args: the instance that wraps the arguments passed for sampling.
      * @param model: the model instance.
-     * @param holder[out]: the object to hold all the information returned to R. 
-     * @param qoi_idx: the indexes for all parameters of interest.  
-     * @param fnames_oi: the parameter names of interest.  
-     * @param base_rng: the boost RNG instance. 
+     * @param holder[out]: the object to hold all the information returned to R.
+     * @param qoi_idx: the indexes for all parameters of interest.
+     * @param fnames_oi: the parameter names of interest.
+     * @param base_rng: the boost RNG instance.
      */
-    template <class Model, class RNG_t> 
+    template <class Model, class RNG_t>
     int sampler_command(stan_args& args, Model& model, Rcpp::List& holder,
-                        const std::vector<size_t>& qoi_idx, 
+                        const std::vector<size_t>& qoi_idx,
                         const std::vector<std::string>& fnames_oi, RNG_t& base_rng) {
 
       base_rng.seed(args.get_random_seed());
       // (2**50 = 1T samples, 1000 chains)
-      static boost::uintmax_t DISCARD_STRIDE = 
+      static boost::uintmax_t DISCARD_STRIDE =
         static_cast<boost::uintmax_t>(1) << 50;
       // rstan::io::rcout << "DISCARD_STRIDE=" << DISCARD_STRIDE << std::endl;
       base_rng.discard(DISCARD_STRIDE * (args.get_chain_id() - 1));
-      
+
       std::vector<double> cont_vector = std::vector<double>(model.num_params_r(), 0);
       std::vector<int> disc_vector = std::vector<int>(model.num_params_i(),0);
       std::vector<double> params_inr_etc; // cont, disc, and others
@@ -617,63 +617,63 @@ namespace rstan {
         try {
           init_log_prob
             = stan::model::log_prob_grad<true,true>(model,
-                                                    cont_vector, 
-                                                    disc_vector, 
-                                                    init_grad, 
+                                                    cont_vector,
+                                                    disc_vector,
+                                                    init_grad,
                                                     &rstan::io::rcout);
         } catch (const std::domain_error& e) {
-          std::string msg("Domain error during initialization with 0:\n"); 
+          std::string msg("Domain error during initialization with 0:\n");
           msg += e.what();
           throw std::runtime_error(msg);
         }
-        if (!boost::math::isfinite(init_log_prob))  
+        if (!boost::math::isfinite(init_log_prob))
           throw std::runtime_error("Error during initialization with 0: vanishing density.");
         for (size_t i = 0; i < init_grad.size(); i++) {
-          if (!boost::math::isfinite(init_grad[i])) 
+          if (!boost::math::isfinite(init_grad[i]))
             throw std::runtime_error("Error during initialization with 0: divergent gradient.");
         }
       } else if (init_val == "user") {
-        try { 
-          rstan::io::rlist_ref_var_context init_var_context(args.get_init_list()); 
+        try {
+          rstan::io::rlist_ref_var_context init_var_context(args.get_init_list());
           model.transform_inits(init_var_context,disc_vector,cont_vector);
           init_log_prob
             = stan::model::log_prob_grad<true,true>(model,
-                                                    cont_vector, 
-                                                    disc_vector, 
-                                                    init_grad, 
+                                                    cont_vector,
+                                                    disc_vector,
+                                                    init_grad,
                                                     &rstan::io::rcout);
         } catch (const std::exception& e) {
-          std::string msg("Error during user-specified initialization:\n"); 
-          msg += e.what(); 
+          std::string msg("Error during user-specified initialization:\n");
+          msg += e.what();
           throw std::runtime_error(msg);
-        } 
-        if (!boost::math::isfinite(init_log_prob))  
+        }
+        if (!boost::math::isfinite(init_log_prob))
           throw std::runtime_error("Rejecting user-specified initialization because of vanishing density.");
         for (size_t i = 0; i < init_grad.size(); i++) {
-          if (!boost::math::isfinite(init_grad[i])) 
+          if (!boost::math::isfinite(init_grad[i]))
             throw std::runtime_error("Rejecting user-specified initialization because of divergent gradient.");
         }
       } else {
-        init_val = "random"; 
+        init_val = "random";
         double r = args.get_init_radius();
-        boost::random::uniform_real_distribution<double> 
+        boost::random::uniform_real_distribution<double>
           init_range_distribution(-r, r);
         boost::variate_generator<RNG_t&, boost::random::uniform_real_distribution<double> >
           init_rng(base_rng,init_range_distribution);
-        
+
         static int MAX_INIT_TRIES = 100;
         for (; num_init_tries < MAX_INIT_TRIES; ++num_init_tries) {
           for (size_t i = 0; i < cont_vector.size(); ++i)
             cont_vector[i] = init_rng();
           try {
-            init_log_prob 
+            init_log_prob
               = stan::model::log_prob_grad<true,true>(model,cont_vector,disc_vector,init_grad,&rstan::io::rcout);
           } catch (const std::domain_error& e) {
             // write_error_msg(&rstan::io::rcout, e);
-            rstan::io::rcout << e.what(); 
+            rstan::io::rcout << e.what();
             rstan::io::rcout << "Rejecting proposed initial value with zero density." << std::endl;
             continue;
-          } 
+          }
           if (!boost::math::isfinite(init_log_prob))
             continue;
           for (size_t i = 0; i < init_grad.size(); ++i)
@@ -682,7 +682,7 @@ namespace rstan {
           break;
         }
         if (num_init_tries == MAX_INIT_TRIES) {
-          rstan::io::rcout << "Initialization failed after " << MAX_INIT_TRIES 
+          rstan::io::rcout << "Initialization failed after " << MAX_INIT_TRIES
                            << " attempts. "
                            << " Try specifying initial values,"
                            << " reducing ranges of constrained values,"
@@ -691,24 +691,24 @@ namespace rstan {
           return -1;
         }
       }
-      // keep a record of the initial values 
+      // keep a record of the initial values
       std::vector<double> initv;
-      model.write_array(base_rng,cont_vector,disc_vector,initv); 
+      model.write_array(base_rng,cont_vector,disc_vector,initv);
 
       if (TEST_GRADIENT == args.get_method()) {
         rstan::io::rcout << std::endl << "TEST GRADIENT MODE" << std::endl;
-        std::stringstream ss; 
+        std::stringstream ss;
         double epsilon = args.get_ctrl_test_grad_epsilon();
         double error = args.get_ctrl_test_grad_error();
         int num_failed = stan::model::test_gradients<true,true>(model,cont_vector,disc_vector,epsilon,error,ss);
-        rstan::io::rcout << ss.str() << std::endl; 
+        rstan::io::rcout << ss.str() << std::endl;
         holder = Rcpp::List::create(Rcpp::_["num_failed"] = num_failed);
         holder.attr("test_grad") = Rcpp::wrap(true);
-        holder.attr("inits") = initv; 
+        holder.attr("inits") = initv;
         return 0;
-      } 
+      }
 
-      std::fstream sample_stream; 
+      std::fstream sample_stream;
       std::fstream diagnostic_stream;
       bool append_samples(args.get_append_samples());
       if (args.get_sample_file_flag()) {
@@ -724,7 +724,7 @@ namespace rstan {
           rstan::io::rcout << "init = " << init_val << std::endl;
           if (num_init_tries > 0)
             rstan::io::rcout << "init tries = " << num_init_tries << std::endl;
-          if (args.get_sample_file_flag()) 
+          if (args.get_sample_file_flag())
             rstan::io::rcout << "output = " << args.get_sample_file() << std::endl;
           rstan::io::rcout << "save_iterations = " << args.get_ctrl_optim_save_iterations() << std::endl;
           rstan::io::rcout << "init_alpha = " << args.get_ctrl_optim_init_alpha() << std::endl;
@@ -735,8 +735,8 @@ namespace rstan {
           rstan::io::rcout << "tol_rel_grad = " << args.get_ctrl_optim_tol_rel_grad() << std::endl;
           rstan::io::rcout << "history_size = " << args.get_ctrl_optim_history_size() << std::endl;
           rstan::io::rcout << "seed = " << args.get_random_seed() << std::endl;
-          
-          if (args.get_sample_file_flag()) { 
+
+          if (args.get_sample_file_flag()) {
             write_comment(sample_stream,"Point Estimate Generated by Stan (LBFGS)");
             write_comment(sample_stream);
             write_comment_property(sample_stream,"stan_version_major",stan::MAJOR_VERSION);
@@ -753,10 +753,10 @@ namespace rstan {
             write_comment_property(sample_stream,"history_size", args.get_ctrl_optim_history_size());
             write_comment_property(sample_stream,"seed",args.get_random_seed());
             write_comment(sample_stream);
-            
+
             sample_stream << "lp__,"; // log probability first
             model.write_csv_header(sample_stream);
-          } 
+          }
 
           double lp(0);
           bool save_iterations = args.get_ctrl_optim_save_iterations();
@@ -774,26 +774,26 @@ namespace rstan {
           lbfgs._conv_opts.tolRelGrad = args.get_ctrl_optim_tol_rel_grad();
           lbfgs._conv_opts.tolAbsX    = args.get_ctrl_optim_tol_param();
           lbfgs._conv_opts.maxIts     = args.get_iter();
-          
+
           int return_code = stan::common::do_bfgs_optimize(model, lbfgs, base_rng,
                                                            lp, cont_vector, disc_vector,
-                                                           &sample_stream, &rstan::io::rcout, 
+                                                           &sample_stream, &rstan::io::rcout,
                                                            save_iterations, refresh);
 
-          if (args.get_sample_file_flag()) { 
+          if (args.get_sample_file_flag()) {
             stan::common::write_iteration(sample_stream, model, base_rng,
                                           lp, cont_vector, disc_vector);
             sample_stream.close();
           }
           model.write_array(base_rng,cont_vector,disc_vector, params_inr_etc);
-          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc, 
+          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc,
                                       Rcpp::_["value"] = lp);
         } else if (BFGS == args.get_ctrl_optim_algorithm()) {
           rstan::io::rcout << "STAN OPTIMIZATION COMMAND (BFGS)" << std::endl;
           rstan::io::rcout << "init = " << init_val << std::endl;
           if (num_init_tries > 0)
             rstan::io::rcout << "init tries = " << num_init_tries << std::endl;
-          if (args.get_sample_file_flag()) 
+          if (args.get_sample_file_flag())
             rstan::io::rcout << "output = " << args.get_sample_file() << std::endl;
           rstan::io::rcout << "save_iterations = " << args.get_ctrl_optim_save_iterations() << std::endl;
           rstan::io::rcout << "init_alpha = " << args.get_ctrl_optim_init_alpha() << std::endl;
@@ -803,8 +803,8 @@ namespace rstan {
           rstan::io::rcout << "tol_rel_obj = " << args.get_ctrl_optim_tol_rel_obj() << std::endl;
           rstan::io::rcout << "tol_rel_grad = " << args.get_ctrl_optim_tol_rel_grad() << std::endl;
           rstan::io::rcout << "seed = " << args.get_random_seed() << std::endl;
-          
-          if (args.get_sample_file_flag()) { 
+
+          if (args.get_sample_file_flag()) {
             write_comment(sample_stream,"Point Estimate Generated by Stan (BFGS)");
             write_comment(sample_stream);
             write_comment_property(sample_stream,"stan_version_major",stan::MAJOR_VERSION);
@@ -820,10 +820,10 @@ namespace rstan {
             write_comment_property(sample_stream,"tol_rel_grad", args.get_ctrl_optim_tol_rel_grad());
             write_comment_property(sample_stream,"seed",args.get_random_seed());
             write_comment(sample_stream);
-            
+
             sample_stream << "lp__,"; // log probability first
             model.write_csv_header(sample_stream);
-          } 
+          }
           double lp(0);
           bool save_iterations = args.get_ctrl_optim_save_iterations();
           int refresh = args.get_ctrl_sampling_refresh();
@@ -838,19 +838,19 @@ namespace rstan {
           bfgs._conv_opts.tolRelGrad = args.get_ctrl_optim_tol_rel_grad();
           bfgs._conv_opts.tolAbsX    = args.get_ctrl_optim_tol_param();
           bfgs._conv_opts.maxIts     = args.get_iter();
-          
+
           int return_code = stan::common::do_bfgs_optimize(model, bfgs, base_rng,
                                                            lp, cont_vector, disc_vector,
-                                                           &sample_stream, &rstan::io::rcout, 
+                                                           &sample_stream, &rstan::io::rcout,
                                                            save_iterations, refresh);
 
-          if (args.get_sample_file_flag()) { 
+          if (args.get_sample_file_flag()) {
             stan::common::write_iteration(sample_stream, model, base_rng,
                                           lp, cont_vector, disc_vector);
             sample_stream.close();
           }
           model.write_array(base_rng,cont_vector,disc_vector, params_inr_etc);
-          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc, 
+          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc,
                                       Rcpp::_["value"] = lp);
         } else if (Newton == args.get_ctrl_optim_algorithm()) {
           rstan::io::rcout << "STAN OPTIMIZATION COMMAND (Newton)" << std::endl;
@@ -863,18 +863,18 @@ namespace rstan {
             write_comment_property(sample_stream,"init",init_val);
             write_comment_property(sample_stream,"seed",args.get_random_seed());
             write_comment(sample_stream);
-  
+
             sample_stream << "lp__,"; // log probability first
             model.write_csv_header(sample_stream);
           }
           std::vector<double> gradient;
           double lp = stan::model::log_prob_grad<true,true>(model, cont_vector, disc_vector, gradient);
-          
+
           double lastlp = lp - 1;
           rstan::io::rcout << "initial log joint probability = " << lp << std::endl;
           int m = 0;
           while ((lp - lastlp) / fabs(lp) > 1e-8) {
-            R_CheckUserInterrupt(); 
+            R_CheckUserInterrupt();
             lastlp = lp;
             lp = stan::optimization::newton_step(model, cont_vector, disc_vector);
             if (args.get_ctrl_optim_refresh() > 0) {
@@ -886,27 +886,27 @@ namespace rstan {
                 rstan::io::rcout.flush();
             }
             m++;
-            if (args.get_sample_file_flag()) { 
+            if (args.get_sample_file_flag()) {
               sample_stream << lp << ',';
               model.write_csv(base_rng,cont_vector,disc_vector,sample_stream);
             }
           }
           model.write_array(base_rng, cont_vector, disc_vector, params_inr_etc);
-          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc, 
+          holder = Rcpp::List::create(Rcpp::_["par"] = params_inr_etc,
                                       Rcpp::_["value"] = lp);
-  
-          if (args.get_sample_file_flag()) { 
+
+          if (args.get_sample_file_flag()) {
             sample_stream << lp << ',';
             print_vector(params_inr_etc, sample_stream);
             sample_stream.close();
           }
         }
         return 0;
-      }  
+      }
       Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(model.num_params_r());
       for (size_t i = 0; i < cont_vector.size(); i++) cont_params(i) = cont_vector[i];
-  
-      // method = 3 //sampling 
+
+      // method = 3 //sampling
       if (args.get_diagnostic_file_flag())
         diagnostic_stream.open(args.get_diagnostic_file().c_str(), std::fstream::out);
 
@@ -915,18 +915,18 @@ namespace rstan {
         write_comment_property(sample_stream,"stan_version_major",stan::MAJOR_VERSION);
         write_comment_property(sample_stream,"stan_version_minor",stan::MINOR_VERSION);
         write_comment_property(sample_stream,"stan_version_patch",stan::PATCH_VERSION);
-        args.write_args_as_comment(sample_stream); 
-      } 
+        args.write_args_as_comment(sample_stream);
+      }
       if (args.get_diagnostic_file_flag()) {
         write_comment(diagnostic_stream,"Samples Generated by Stan");
         write_comment_property(diagnostic_stream,"stan_version_major",stan::MAJOR_VERSION);
         write_comment_property(diagnostic_stream,"stan_version_minor",stan::MINOR_VERSION);
         write_comment_property(diagnostic_stream,"stan_version_patch",stan::PATCH_VERSION);
         args.write_args_as_comment(diagnostic_stream);
-      } 
-     
+      }
+
       int engine_index = 0;
-       
+
       sampling_metric_t metric = args.get_ctrl_sampling_metric(); // unit_e, diag_e, dense_e;
       int metric_index = 0;
       if (UNIT_E == metric) metric_index = 0;
@@ -949,14 +949,14 @@ namespace rstan {
                          sample_stream, diagnostic_stream, fnames_oi,
                          base_rng);
         return 0;
-        
+
       }
       switch (algorithm) {
          case Metropolis: engine_index = 3; break;
          case HMC: engine_index = 0; break;
          case NUTS: engine_index = 1; break;
          default: engine_index = 10000; // make it fail in the end
-      } 
+      }
 
       int sampler_select = engine_index + 10 * metric_index;
       if (args.get_ctrl_sampling_adapt_engaged())  sampler_select += 100;
@@ -1075,116 +1075,116 @@ namespace rstan {
                            base_rng);
           break;
         }
-        default: 
+        default:
           throw std::invalid_argument("No sampler matching HMC specification!");
-      } 
+      }
       return 0;
     }
   }
 
 
 
-  template <class Model, class RNG_t> 
+  template <class Model, class RNG_t>
   class stan_fit {
 
   private:
     io::rlist_ref_var_context data_;
     Model model_;
-    RNG_t base_rng; 
+    RNG_t base_rng;
     const std::vector<std::string> names_;
-    const std::vector<std::vector<unsigned int> > dims_; 
-    const unsigned int num_params_; 
+    const std::vector<std::vector<unsigned int> > dims_;
+    const unsigned int num_params_;
 
-    std::vector<std::string> names_oi_; // parameters of interest 
-    std::vector<std::vector<unsigned int> > dims_oi_; 
+    std::vector<std::string> names_oi_; // parameters of interest
+    std::vector<std::vector<unsigned int> > dims_oi_;
     std::vector<size_t> names_oi_tidx_;  // the total indexes of names2.
     // std::vector<size_t> midx_for_col2row; // indices for mapping col-major to row-major
-    std::vector<unsigned int> starts_oi_;  
-    unsigned int num_params2_;  // total number of POI's.   
-    std::vector<std::string> fnames_oi_; 
+    std::vector<unsigned int> starts_oi_;
+    unsigned int num_params2_;  // total number of POI's.
+    std::vector<std::string> fnames_oi_;
     Rcpp::Function cxxfunction; // keep a reference to the cxxfun, no functional purpose.
 
-  private: 
+  private:
     /**
-     * Tell if a parameter name is an element of an array parameter. 
-     * Note that it only supports full specified name; slicing 
-     * is not supported. The test only tries to see if there 
-     * are brackets. 
+     * Tell if a parameter name is an element of an array parameter.
+     * Note that it only supports full specified name; slicing
+     * is not supported. The test only tries to see if there
+     * are brackets.
      */
     bool is_flatname(const std::string& name) {
-      return name.find('[') != name.npos && name.find(']') != name.npos; 
-    } 
-  
+      return name.find('[') != name.npos && name.find(']') != name.npos;
+    }
+
     /*
-     * Update the parameters we are interested for the model. 
-     * As well, the dimensions vector for the parameters are 
-     * updated. 
+     * Update the parameters we are interested for the model.
+     * As well, the dimensions vector for the parameters are
+     * updated.
      */
     void update_param_oi0(const std::vector<std::string>& pnames) {
-      names_oi_.clear(); 
-      dims_oi_.clear(); 
-      names_oi_tidx_.clear(); 
+      names_oi_.clear();
+      dims_oi_.clear();
+      names_oi_tidx_.clear();
 
-      std::vector<unsigned int> starts; 
+      std::vector<unsigned int> starts;
       calc_starts(dims_, starts);
-      for (std::vector<std::string>::const_iterator it = pnames.begin(); 
-           it != pnames.end(); 
-           ++it) { 
-        size_t p = find_index(names_, *it); 
+      for (std::vector<std::string>::const_iterator it = pnames.begin();
+           it != pnames.end();
+           ++it) {
+        size_t p = find_index(names_, *it);
         if (p != names_.size()) {
-          names_oi_.push_back(*it); 
-          dims_oi_.push_back(dims_[p]); 
+          names_oi_.push_back(*it);
+          dims_oi_.push_back(dims_[p]);
           if (*it == "lp__") {
-            names_oi_tidx_.push_back(-1); // -1 for lp__ as it is not really a parameter  
+            names_oi_tidx_.push_back(-1); // -1 for lp__ as it is not really a parameter
             continue;
-          } 
-          size_t i_num = calc_num_params(dims_[p]); 
-          size_t i_start = starts[p]; 
+          }
+          size_t i_num = calc_num_params(dims_[p]);
+          size_t i_start = starts[p];
           for (size_t j = i_start; j < i_start + i_num; j++)
             names_oi_tidx_.push_back(j);
-        } 
+        }
       }
       calc_starts(dims_oi_, starts_oi_);
-      num_params2_ = names_oi_tidx_.size(); 
-    } 
+      num_params2_ = names_oi_tidx_.size();
+    }
 
   public:
     SEXP update_param_oi(SEXP pars) {
-      std::vector<std::string> pnames = 
-        Rcpp::as<std::vector<std::string> >(pars);  
-      if (std::find(pnames.begin(), pnames.end(), "lp__") == pnames.end()) 
-        pnames.push_back("lp__"); 
-      update_param_oi0(pnames); 
-      get_all_flatnames(names_oi_, dims_oi_, fnames_oi_, true); 
-      return Rcpp::wrap(true); 
-    } 
+      std::vector<std::string> pnames =
+        Rcpp::as<std::vector<std::string> >(pars);
+      if (std::find(pnames.begin(), pnames.end(), "lp__") == pnames.end())
+        pnames.push_back("lp__");
+      update_param_oi0(pnames);
+      get_all_flatnames(names_oi_, dims_oi_, fnames_oi_, true);
+      return Rcpp::wrap(true);
+    }
 
-    stan_fit(SEXP data, SEXP cxxf) : 
+    stan_fit(SEXP data, SEXP cxxf) :
       data_(data),
-      model_(data_, &rstan::io::rcout),  
+      model_(data_, &rstan::io::rcout),
       base_rng(static_cast<boost::uint32_t>(std::time(0))),
-      names_(get_param_names(model_)), 
-      dims_(get_param_dims(model_)), 
-      num_params_(calc_total_num_params(dims_)), 
-      names_oi_(names_), 
+      names_(get_param_names(model_)),
+      dims_(get_param_dims(model_)),
+      num_params_(calc_total_num_params(dims_)),
+      names_oi_(names_),
       dims_oi_(dims_),
       num_params2_(num_params_),
-      cxxfunction(cxxf)  
+      cxxfunction(cxxf)
     {
-      for (size_t j = 0; j < num_params2_ - 1; j++) 
+      for (size_t j = 0; j < num_params2_ - 1; j++)
         names_oi_tidx_.push_back(j);
       names_oi_tidx_.push_back(-1); // lp__
       calc_starts(dims_oi_, starts_oi_);
-      get_all_flatnames(names_oi_, dims_oi_, fnames_oi_, true); 
+      get_all_flatnames(names_oi_, dims_oi_, fnames_oi_, true);
       // get_all_indices_col2row(dims_, midx_for_col2row);
-    }             
+    }
 
     /**
      * Transform the parameters from its defined support
-     * to unconstrained space 
-     * 
+     * to unconstrained space
+     *
      * @param par An R list as for specifying the initial values
-     *  for a chain 
+     *  for a chain
      */
     SEXP unconstrain_pars(SEXP par) {
       BEGIN_RCPP
@@ -1197,52 +1197,52 @@ namespace rstan {
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     SEXP unconstrained_param_names(SEXP include_tparams, SEXP include_gqs) {
       BEGIN_RCPP
       std::vector<std::string> n;
-      model_.unconstrained_param_names(n, Rcpp::as<bool>(include_tparams), 
+      model_.unconstrained_param_names(n, Rcpp::as<bool>(include_tparams),
                                        Rcpp::as<bool>(include_gqs));
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(n));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     SEXP constrained_param_names(SEXP include_tparams, SEXP include_gqs) {
       BEGIN_RCPP
       std::vector<std::string> n;
-      model_.constrained_param_names(n, Rcpp::as<bool>(include_tparams), 
+      model_.constrained_param_names(n, Rcpp::as<bool>(include_tparams),
                                      Rcpp::as<bool>(include_gqs));
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(n));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     /**
      * Contrary to unconstrain_pars, transform parameters
-     * from unconstrained support to the constrained. 
-     * 
-     * @param upar The parameter values on the unconstrained 
-     *  space 
-     */ 
+     * from unconstrained support to the constrained.
+     *
+     * @param upar The parameter values on the unconstrained
+     *  space
+     */
     SEXP constrain_pars(SEXP upar) {
       BEGIN_RCPP
       std::vector<double> par;
       std::vector<double> params_r = Rcpp::as<std::vector<double> >(upar);
       if (params_r.size() != model_.num_params_r()) {
-        std::stringstream msg; 
-        msg << "Number of unconstrained parameters does not match " 
-               "that of the model (" 
-            << params_r.size() << " vs " 
-            << model_.num_params_r() 
+        std::stringstream msg;
+        msg << "Number of unconstrained parameters does not match "
+               "that of the model ("
+            << params_r.size() << " vs "
+            << model_.num_params_r()
             << ").";
-        throw std::domain_error(msg.str()); 
-      } 
+        throw std::domain_error(msg.str());
+      }
       std::vector<int> params_i(model_.num_params_i());
       model_.write_array(base_rng, params_r, params_i, par);
       SEXP __sexp_result;
@@ -1250,42 +1250,42 @@ namespace rstan {
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
-  
+    }
+
     /**
      * Expose the log_prob of the model to stan_fit so R user
-     * can call this function. 
-     * 
-     * @param upar The real parameters on the unconstrained 
-     *  space. 
+     * can call this function.
+     *
+     * @param upar The real parameters on the unconstrained
+     *  space.
      */
     SEXP log_prob(SEXP upar, SEXP jacobian_adjust_transform, SEXP gradient) {
       BEGIN_RCPP
       using std::vector;
       vector<double> par_r = Rcpp::as<vector<double> >(upar);
       if (par_r.size() != model_.num_params_r()) {
-        std::stringstream msg; 
-        msg << "Number of unconstrained parameters does not match " 
-               "that of the model (" 
-            << par_r.size() << " vs " 
-            << model_.num_params_r() 
+        std::stringstream msg;
+        msg << "Number of unconstrained parameters does not match "
+               "that of the model ("
+            << par_r.size() << " vs "
+            << model_.num_params_r()
             << ").";
-        throw std::domain_error(msg.str()); 
-      } 
+        throw std::domain_error(msg.str());
+      }
       vector<int> par_i(model_.num_params_i(), 0);
-      if (!Rcpp::as<bool>(gradient)) { 
+      if (!Rcpp::as<bool>(gradient)) {
         if (Rcpp::as<bool>(jacobian_adjust_transform)) {
           return Rcpp::wrap(stan::model::log_prob_propto<true>(model_, par_r, par_i, &rstan::io::rcout));
         } else {
           return Rcpp::wrap(stan::model::log_prob_propto<false>(model_, par_r, par_i, &rstan::io::rcout));
-        } 
-      } 
+        }
+      }
 
-      std::vector<double> gradient; 
+      std::vector<double> gradient;
       double lp;
-      if (Rcpp::as<bool>(jacobian_adjust_transform)) 
+      if (Rcpp::as<bool>(jacobian_adjust_transform))
         lp = stan::model::log_prob_grad<true,true>(model_, par_r, par_i, gradient, &rstan::io::rcout);
-      else 
+      else
         lp = stan::model::log_prob_grad<true,false>(model_, par_r, par_i, gradient, &rstan::io::rcout);
       Rcpp::NumericVector lp2 = Rcpp::wrap(lp);
       lp2.attr("gradient") = gradient;
@@ -1294,14 +1294,14 @@ namespace rstan {
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     /**
      * Expose the grad_log_prob of the model to stan_fit so R user
-     * can call this function. 
-     * 
-     * @param upar The real parameters on the unconstrained 
-     *  space. 
+     * can call this function.
+     *
+     * @param upar The real parameters on the unconstrained
+     *  space.
      * @param jacobian_adjust_transform TRUE/FALSE, whether
      *  we add the term due to the transform from constrained
      *  space to unconstrained space implicitly done in Stan.
@@ -1310,33 +1310,33 @@ namespace rstan {
       BEGIN_RCPP
       std::vector<double> par_r = Rcpp::as<std::vector<double> >(upar);
       if (par_r.size() != model_.num_params_r()) {
-        std::stringstream msg; 
-        msg << "Number of unconstrained parameters does not match " 
-               "that of the model (" 
-            << par_r.size() << " vs " 
-            << model_.num_params_r() 
+        std::stringstream msg;
+        msg << "Number of unconstrained parameters does not match "
+               "that of the model ("
+            << par_r.size() << " vs "
+            << model_.num_params_r()
             << ").";
-        throw std::domain_error(msg.str()); 
-      } 
+        throw std::domain_error(msg.str());
+      }
       std::vector<int> par_i(model_.num_params_i(), 0);
-      std::vector<double> gradient; 
+      std::vector<double> gradient;
       double lp;
-      if (Rcpp::as<bool>(jacobian_adjust_transform)) 
+      if (Rcpp::as<bool>(jacobian_adjust_transform))
         lp = stan::model::log_prob_grad<true,true>(model_, par_r, par_i, gradient, &rstan::io::rcout);
-      else 
+      else
         lp = stan::model::log_prob_grad<true,false>(model_, par_r, par_i, gradient, &rstan::io::rcout);
-      Rcpp::NumericVector grad = Rcpp::wrap(gradient); 
+      Rcpp::NumericVector grad = Rcpp::wrap(gradient);
       grad.attr("log_prob") = lp;
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(grad));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     /**
-     * Return the number of unconstrained parameters 
-     */ 
+     * Return the number of unconstrained parameters
+     */
     SEXP num_pars_unconstrained() {
       BEGIN_RCPP
       int n = model_.num_params_r();
@@ -1345,137 +1345,137 @@ namespace rstan {
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
-    
-    SEXP call_sampler(SEXP args_) { 
-      BEGIN_RCPP 
-      Rcpp::List lst_args(args_); 
-      stan_args args(lst_args); 
+    }
+
+    SEXP call_sampler(SEXP args_) {
+      BEGIN_RCPP
+      Rcpp::List lst_args(args_);
+      stan_args args(lst_args);
       Rcpp::List holder;
 
       int ret;
-      ret = sampler_command(args, model_, holder, names_oi_tidx_, 
+      ret = sampler_command(args, model_, holder, names_oi_tidx_,
                             fnames_oi_, base_rng);
       if (ret != 0) {
-        return R_NilValue;  // indicating error happened 
-      } 
+        return R_NilValue;  // indicating error happened
+      }
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(holder));
       UNPROTECT(1);
       return __sexp_result;
-      END_RCPP 
-    } 
+      END_RCPP
+    }
 
     SEXP param_names() const {
-      BEGIN_RCPP 
+      BEGIN_RCPP
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(names_));
       UNPROTECT(1);
       return __sexp_result;
-      END_RCPP 
-    } 
+      END_RCPP
+    }
 
     SEXP param_names_oi() const {
-      BEGIN_RCPP 
+      BEGIN_RCPP
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(names_oi_));
       UNPROTECT(1);
       return __sexp_result;
-      END_RCPP 
-    } 
+      END_RCPP
+    }
 
     /**
-     * tidx (total indexes) 
-     * the index is among those parameters of interest, not 
-     * all the parameters. 
-     */ 
+     * tidx (total indexes)
+     * the index is among those parameters of interest, not
+     * all the parameters.
+     */
     SEXP param_oi_tidx(SEXP pars) {
-      BEGIN_RCPP 
-      std::vector<std::string> names = 
-        Rcpp::as<std::vector<std::string> >(pars); 
-      std::vector<std::string> names2; 
-      std::vector<std::vector<unsigned int> > indexes; 
+      BEGIN_RCPP
+      std::vector<std::string> names =
+        Rcpp::as<std::vector<std::string> >(pars);
+      std::vector<std::string> names2;
+      std::vector<std::vector<unsigned int> > indexes;
       for (std::vector<std::string>::const_iterator it = names.begin();
-           it != names.end(); 
+           it != names.end();
            ++it) {
-        if (is_flatname(*it)) { // an element of an array  
+        if (is_flatname(*it)) { // an element of an array
           size_t ts = std::distance(fnames_oi_.begin(),
-                                    std::find(fnames_oi_.begin(), 
-                                              fnames_oi_.end(), *it));       
-          if (ts == fnames_oi_.size()) // not found 
-            continue; 
-          names2.push_back(*it); 
-          indexes.push_back(std::vector<unsigned int>(1, ts)); 
+                                    std::find(fnames_oi_.begin(),
+                                              fnames_oi_.end(), *it));
+          if (ts == fnames_oi_.size()) // not found
+            continue;
+          names2.push_back(*it);
+          indexes.push_back(std::vector<unsigned int>(1, ts));
           continue;
         }
-        size_t j = std::distance(names_oi_.begin(), 
-                                 std::find(names_oi_.begin(),    
-                                           names_oi_.end(), *it)); 
-        if (j == names_oi_.size()) // not found 
-          continue; 
-        unsigned int j_size = calc_num_params(dims_oi_[j]); 
-        unsigned int j_start = starts_oi_[j]; 
-        std::vector<unsigned int> j_idx; 
+        size_t j = std::distance(names_oi_.begin(),
+                                 std::find(names_oi_.begin(),
+                                           names_oi_.end(), *it));
+        if (j == names_oi_.size()) // not found
+          continue;
+        unsigned int j_size = calc_num_params(dims_oi_[j]);
+        unsigned int j_start = starts_oi_[j];
+        std::vector<unsigned int> j_idx;
         for (unsigned int k = 0; k < j_size; k++) {
-          j_idx.push_back(j_start + k); 
-        } 
-        names2.push_back(*it); 
-        indexes.push_back(j_idx); 
+          j_idx.push_back(j_start + k);
+        }
+        names2.push_back(*it);
+        indexes.push_back(j_idx);
       }
-      Rcpp::List lst = Rcpp::wrap(indexes); 
-      lst.names() = names2; 
+      Rcpp::List lst = Rcpp::wrap(indexes);
+      lst.names() = names2;
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(lst));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
 
     SEXP param_dims() const {
-      BEGIN_RCPP 
-      Rcpp::List lst = Rcpp::wrap(dims_); 
-      lst.names() = names_; 
+      BEGIN_RCPP
+      Rcpp::List lst = Rcpp::wrap(dims_);
+      lst.names() = names_;
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(lst));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
 
     SEXP param_dims_oi() const {
-      BEGIN_RCPP 
-      Rcpp::List lst = Rcpp::wrap(dims_oi_); 
-      lst.names() = names_oi_; 
+      BEGIN_RCPP
+      Rcpp::List lst = Rcpp::wrap(dims_oi_);
+      lst.names() = names_oi_;
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(lst));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
-    
+    }
+
     SEXP param_fnames_oi() const {
-      BEGIN_RCPP 
-      std::vector<std::string> fnames; 
-      get_all_flatnames(names_oi_, dims_oi_, fnames, true); 
+      BEGIN_RCPP
+      std::vector<std::string> fnames;
+      get_all_flatnames(names_oi_, dims_oi_, fnames, true);
       SEXP __sexp_result;
       PROTECT(__sexp_result = Rcpp::wrap(fnames));
       UNPROTECT(1);
       return __sexp_result;
       END_RCPP
-    } 
+    }
   };
-} 
+}
 
-#endif 
+#endif
 
 /*
  * compile to check syntax error
  */
 /*
-STAN= ../../../../../ 
+STAN= ../../../../../
 RCPPINC=`Rscript -e "cat(system.file('include', package='Rcpp'))"`
-RINC=`Rscript -e "cat(R.home('include'))"` 
-g++ -Wall -I${RINC} -I"${STAN}/lib/boost_1.51.0" -I"${STAN}/lib/eigen_3.1.1"  -I"${STAN}/src" -I"${RCPPINC}" -I"../" stan_fit.hpp 
+RINC=`Rscript -e "cat(R.home('include'))"`
+g++ -Wall -I${RINC} -I"${STAN}/lib/boost_1.51.0" -I"${STAN}/lib/eigen_3.1.1"  -I"${STAN}/src" -I"${RCPPINC}" -I"../" stan_fit.hpp
 */
 

--- a/rstan/rstan/src/agrad__rev__var_stack.cpp
+++ b/rstan/rstan/src/agrad__rev__var_stack.cpp
@@ -1,3 +1,3 @@
-#include <stan/agrad/rev/var_stack.cpp> 
+#include <stan/agrad/rev/var_stack.cpp>
 
 

--- a/rstan/rstan/src/chains.cpp
+++ b/rstan/rstan/src/chains.cpp
@@ -1,4 +1,4 @@
-// #include <stan/mcmc/chains.hpp> 
+// #include <stan/mcmc/chains.hpp>
 #include <stan/math/matrix.hpp>
 #include <stan/prob/autocorrelation.hpp>
 #include <stan/prob/autocovariance.hpp>
@@ -15,143 +15,143 @@
 
 namespace rstan {
 
-  namespace { 
+  namespace {
     /*
-     * Wrap up the arguments for creating a sequence of indexes for permutation 
-     * Rcpp::List and set the defaults if not available. 
+     * Wrap up the arguments for creating a sequence of indexes for permutation
+     * Rcpp::List and set the defaults if not available.
      *
-     * Arguments n and chains must be in the named list; others are optional. 
+     * Arguments n and chains must be in the named list; others are optional.
      *
      * <ul>
-     * <li>  n: total length 
-     * <li>  chains: number of chains 
-     * <li>  seed: seed for RNG 
-     * <li>  chain_id: chain id 
+     * <li>  n: total length
+     * <li>  chains: number of chains
+     * <li>  seed: seed for RNG
+     * <li>  chain_id: chain id
      * </ul>
-     */ 
+     */
     class perm_args {
     private:
-      int n, chains, chain_id;  
-      unsigned int seed; 
+      int n, chains, chain_id;
+      unsigned int seed;
 
-      inline unsigned int sexp2seed(SEXP seed) { 
-        if (TYPEOF(seed) == STRSXP)  
+      inline unsigned int sexp2seed(SEXP seed) {
+        if (TYPEOF(seed) == STRSXP)
           return boost::lexical_cast<unsigned int>(Rcpp::as<std::string>(seed));
-        return Rcpp::as<unsigned int>(seed); 
+        return Rcpp::as<unsigned int>(seed);
       }
-  
+
     public:
-      perm_args(Rcpp::List& lst) : chain_id(1) { 
-        if (!lst.containsElementNamed("n")) 
-          throw std::runtime_error("number of iterations kept (n) is not specified"); 
-        n = Rcpp::as<int>(lst["n"]); 
-  
-        if (!lst.containsElementNamed("chains")) 
-          throw std::runtime_error("number of chains is not specified"); 
+      perm_args(Rcpp::List& lst) : chain_id(1) {
+        if (!lst.containsElementNamed("n"))
+          throw std::runtime_error("number of iterations kept (n) is not specified");
+        n = Rcpp::as<int>(lst["n"]);
+
+        if (!lst.containsElementNamed("chains"))
+          throw std::runtime_error("number of chains is not specified");
         chains = Rcpp::as<int>(lst["chains"]);
-  
-        if (lst.containsElementNamed("chain_id")) 
-          chain_id = Rcpp::as<int>(lst["chain_id"]); 
-  
-        if (lst.containsElementNamed("seed")) 
-          seed = sexp2seed(lst["seed"]); 
-        else 
-          seed = std::time(0); 
-      } 
-  
-      inline int get_n() const { return n; } 
-      inline int get_chain_id() const { return chain_id; } 
-      inline unsigned int get_seed() const { return seed; } 
-      inline int get_chains() const { return chains; } 
-  
-      inline SEXP perm_args_to_rlist() const {
-        Rcpp::List lst; 
-        std::stringstream ss; 
-        ss << seed; 
-        lst["seed"] = ss.str();  
-        lst["n"] = n; 
-        lst["chain_id"] = chain_id;
-        lst["chains"] = chains; 
-        return lst; 
+
+        if (lst.containsElementNamed("chain_id"))
+          chain_id = Rcpp::as<int>(lst["chain_id"]);
+
+        if (lst.containsElementNamed("seed"))
+          seed = sexp2seed(lst["seed"]);
+        else
+          seed = std::time(0);
       }
-    }; 
+
+      inline int get_n() const { return n; }
+      inline int get_chain_id() const { return chain_id; }
+      inline unsigned int get_seed() const { return seed; }
+      inline int get_chains() const { return chains; }
+
+      inline SEXP perm_args_to_rlist() const {
+        Rcpp::List lst;
+        std::stringstream ss;
+        ss << seed;
+        lst["seed"] = ss.str();
+        lst["n"] = n;
+        lst["chain_id"] = chain_id;
+        lst["chains"] = chains;
+        return lst;
+      }
+    };
 
     /**
      * @param sim An R list that has element chains, n_flatnames, samples,
-     *  n_save, warmup2, etc. In particular, 
-     *  chains: number of chains. 
-     *  n_flatnames: the total number of param in form of scalars.  
-     *  n_save: sizes of saved iterations for all chains. 
+     *  n_save, warmup2, etc. In particular,
+     *  chains: number of chains.
+     *  n_flatnames: the total number of param in form of scalars.
+     *  n_save: sizes of saved iterations for all chains.
      *  warmup2: simiar to n_save, but for warmup sizes. Note this warmup
      *  might be different from the warmup specified by the user for running
-     *  the sampler because thinning is accounted in warmup2. 
-     *  samples: A list for saved samples. Each element is a list for a chain. 
+     *  the sampler because thinning is accounted in warmup2.
+     *  samples: A list for saved samples. Each element is a list for a chain.
      *    Each chain is a list as well, every element of which is a chain of
-     *    samples for a parameter. 
-     *  
-     */ 
+     *    samples for a parameter.
+     *
+     */
     void validate_sim(SEXP sim) {
       std::vector<std::string> snames;
-      snames.push_back("chains"); 
-      snames.push_back("n_flatnames"); 
+      snames.push_back("chains");
+      snames.push_back("n_flatnames");
       snames.push_back("n_save");
       snames.push_back("warmup2");
       snames.push_back("samples");
       snames.push_back("permutation");
-      Rcpp::List lst(sim); 
-      std::vector<std::string> names = lst.names(); 
-      
-      for (std::vector<std::string>::const_iterator it = snames.begin(); 
-           it != snames.end(); 
-           ++it) { 
+      Rcpp::List lst(sim);
+      std::vector<std::string> names = lst.names();
+
+      for (std::vector<std::string>::const_iterator it = snames.begin();
+           it != snames.end();
+           ++it) {
          if (std::find(names.begin(), names.end(), *it) == names.end()) {
            std::stringstream msg;
-           msg << "the simulation results (sim) does not contain " << *it; 
-           throw std::domain_error(msg.str()); 
-         } 
+           msg << "the simulation results (sim) does not contain " << *it;
+           throw std::domain_error(msg.str());
+         }
       }
-  
-      unsigned int type = TYPEOF(lst["chains"]); 
-      if (type != INTSXP &&  type != REALSXP) { 
+
+      unsigned int type = TYPEOF(lst["chains"]);
+      if (type != INTSXP &&  type != REALSXP) {
         std::stringstream msg;
-        msg << "wrong type of chains in sim; found " 
-            << Rf_type2char(type) 
-            << ", but INTSXP/REALSXP needed"; 
-        throw std::domain_error(msg.str()); 
-      } 
-    } 
-  
+        msg << "wrong type of chains in sim; found "
+            << Rf_type2char(type)
+            << ", but INTSXP/REALSXP needed";
+        throw std::domain_error(msg.str());
+      }
+    }
+
     unsigned int num_chains(SEXP sim) {
-      Rcpp::List lst(sim); 
-      return Rcpp::as<unsigned int>(lst["chains"]); 
-    } 
-  
+      Rcpp::List lst(sim);
+      return Rcpp::as<unsigned int>(lst["chains"]);
+    }
+
     unsigned int num_params(SEXP sim) {
-      Rcpp::List lst(sim); 
-      return Rcpp::as<unsigned int>(lst["n_flatnames"]); 
-    } 
-    /** 
+      Rcpp::List lst(sim);
+      return Rcpp::as<unsigned int>(lst["n_flatnames"]);
+    }
+    /**
      *
      * @param k Chain index starting from 0
      * @param n Parameer index starting from 0
-     */ 
-    void get_kept_samples(SEXP sim, const size_t k, const size_t n, 
+     */
+    void get_kept_samples(SEXP sim, const size_t k, const size_t n,
                           std::vector<double>& samples) {
-      Rcpp::List lst(sim); 
-      if (TYPEOF(lst["samples"]) != VECSXP) { 
+      Rcpp::List lst(sim);
+      if (TYPEOF(lst["samples"]) != VECSXP) {
         std::stringstream msg;
-        msg << "sim$samples is not a list"; 
-        throw std::domain_error(msg.str()); 
-      } 
-      Rcpp::List allsamples(static_cast<SEXP>(lst["samples"])); 
-      Rcpp::IntegerVector n_save(static_cast<SEXP>(lst["n_save"])); 
-      Rcpp::IntegerVector warmup2(static_cast<SEXP>(lst["warmup2"])); 
-    
+        msg << "sim$samples is not a list";
+        throw std::domain_error(msg.str());
+      }
+      Rcpp::List allsamples(static_cast<SEXP>(lst["samples"]));
+      Rcpp::IntegerVector n_save(static_cast<SEXP>(lst["n_save"]));
+      Rcpp::IntegerVector warmup2(static_cast<SEXP>(lst["warmup2"]));
+
       Rcpp::List slst(static_cast<SEXP>(allsamples[k]));  // chain k
-      Rcpp::NumericVector nv(static_cast<SEXP>(slst[n])); // parameter n  
-      samples.assign(warmup2[k] + nv.begin(), nv.end()); 
-    } 
-  
+      Rcpp::NumericVector nv(static_cast<SEXP>(slst[n])); // parameter n
+      samples.assign(warmup2[k] + nv.begin(), nv.end());
+    }
+
     void validate_param_idx(SEXP sim, size_t n) {
       if (n < num_params(sim))
         return;
@@ -160,35 +160,35 @@ namespace rstan {
           << "; found n=" << n;
       throw std::out_of_range(msg.str());
     }
-  
+
     void validate_chain_idx(SEXP sim, unsigned int k) {
-      unsigned int m = num_chains(sim); 
-      if (k >= m) { 
+      unsigned int m = num_chains(sim);
+      if (k >= m) {
         std::stringstream msg;
         msg << "chain must be less than number of chains."
-            << "; num chains=" << m 
+            << "; num chains=" << m
             << "; chain=" << k;
         throw std::out_of_range(msg.str());
       }
     }
-  
+
     template <typename F>
     void apply_kept_samples(SEXP sim, size_t k,
                             size_t n,
                             F& f) {
-      Rcpp::List lst(sim); 
-      Rcpp::List allsamples(static_cast<SEXP>(lst["samples"])); 
-      Rcpp::IntegerVector n_save(static_cast<SEXP>(lst["n_save"])); 
-      Rcpp::IntegerVector warmup2(static_cast<SEXP>(lst["warmup2"])); 
-  
+      Rcpp::List lst(sim);
+      Rcpp::List allsamples(static_cast<SEXP>(lst["samples"]));
+      Rcpp::IntegerVector n_save(static_cast<SEXP>(lst["n_save"]));
+      Rcpp::IntegerVector warmup2(static_cast<SEXP>(lst["warmup2"]));
+
       Rcpp::List slst(static_cast<SEXP>(allsamples[k]));  // chain k
-      Rcpp::NumericVector nv(static_cast<SEXP>(slst[n])); // parameter n  
-      // use int instead of size_t since these are R integers. 
+      Rcpp::NumericVector nv(static_cast<SEXP>(slst[n])); // parameter n
+      // use int instead of size_t since these are R integers.
       for (int i = warmup2[k]; i < n_save[k]; i++) {
-        f(nv[i]); 
-      } 
+        f(nv[i]);
+      }
     }
-  
+
     double get_chain_mean(SEXP sim, size_t k, size_t n) {
       using boost::accumulators::accumulator_set;
       using boost::accumulators::stats;
@@ -199,16 +199,16 @@ namespace rstan {
       apply_kept_samples(sim, k,n,acc);
       return boost::accumulators::mean(acc);
     }
-  
-    /** 
+
+    /**
      * Returns the autocovariance for the specified parameter in the
      * kept samples of the chain specified.
-     * 
+     *
      * @param[in] k Chain index
      * @param[in] n Parameter index
      * @param[out] acov Autocovariances
      */
-    void autocovariance(SEXP sim, const size_t k, const size_t n, 
+    void autocovariance(SEXP sim, const size_t k, const size_t n,
                         std::vector<double>& acov) {
       std::vector<double> samples;
       get_kept_samples(sim,k,n,samples);
@@ -216,25 +216,25 @@ namespace rstan {
     }
 
     /**
-     * Read comments beggining with `#` in the csv file of samples 
-     * generated by Stan 
-     * @param filename The file name for the csv file 
-     * @param n Maximum number of lines of comments to read 
-     * @param comments A vector to which each line of comments is added  
-     */ 
-    void read_comments0(const std::string& filename, size_t n, 
+     * Read comments beggining with `#` in the csv file of samples
+     * generated by Stan
+     * @param filename The file name for the csv file
+     * @param n Maximum number of lines of comments to read
+     * @param comments A vector to which each line of comments is added
+     */
+    void read_comments0(const std::string& filename, size_t n,
                         std::vector<std::string>& comments) {
       const std::streamsize max_ignore_len = std::numeric_limits<std::streamsize>::max();
-      comments.clear(); 
+      comments.clear();
       std::fstream fs(filename.c_str(), std::fstream::in);
       if (!fs.is_open())
         throw std::runtime_error("Could not open " + filename);
       size_t i = 0;
       std::string line;
-      char peek; 
+      char peek;
       while (i < n) {
         peek = fs.peek();
-        if (peek == std::istream::traits_type::eof()) return; 
+        if (peek == std::istream::traits_type::eof()) return;
         if (peek != '#') {
           fs.ignore(max_ignore_len, '#');
           if (fs.eof()) return;
@@ -245,60 +245,60 @@ namespace rstan {
         std::getline(fs, line, '\n');
         comments.push_back(line);
         i++;
-      } 
+      }
       fs.close();
     }
-  } 
-} 
+  }
+}
 
-RcppExport SEXP effective_sample_size(SEXP sim, SEXP n_); 
+RcppExport SEXP effective_sample_size(SEXP sim, SEXP n_);
 RcppExport SEXP effective_sample_size2(SEXP sims);
-RcppExport SEXP split_potential_scale_reduction(SEXP sim, SEXP n_); 
+RcppExport SEXP split_potential_scale_reduction(SEXP sim, SEXP n_);
 RcppExport SEXP split_potential_scale_reduction2(SEXP sims_);
-RcppExport SEXP seq_permutation(SEXP conf);  
+RcppExport SEXP seq_permutation(SEXP conf);
 RcppExport SEXP CPP_read_comments(SEXP file, SEXP n);
 
 RcppExport SEXP stan_prob_autocovariance(SEXP v);
 
-/** 
+/**
  * Returns the effective sample size for the specified parameter
  * across all kept samples.
  *
  * The implementation matches BDA3's effective size description.
- * 
+ *
  * Current implementation takes the minimum number of samples
  * across chains as the number of samples per chain.
  *
- * @param[in] sim An R list containing simulated samples 
- *  and all other related information such as number of 
- *  iterations (warmup, etc), and parameter information.  
+ * @param[in] sim An R list containing simulated samples
+ *  and all other related information such as number of
+ *  iterations (warmup, etc), and parameter information.
  * @param[in] n Parameter index
- * 
+ *
  * @return The effective sample size.
  */
 // FIXME: reimplement using autocorrelation.
-SEXP effective_sample_size(SEXP sim, SEXP n_) { 
-  BEGIN_RCPP 
-  rstan::validate_sim(sim); 
-  Rcpp::List lst(sim); 
-  unsigned int n = Rcpp::as<unsigned int>(n_); 
+SEXP effective_sample_size(SEXP sim, SEXP n_) {
+  BEGIN_RCPP
+  rstan::validate_sim(sim);
+  Rcpp::List lst(sim);
+  unsigned int n = Rcpp::as<unsigned int>(n_);
   rstan::validate_param_idx(sim,n);
-  unsigned int m(rstan::num_chains(sim)); 
+  unsigned int m(rstan::num_chains(sim));
   // need to generalize to each jagged samples per chain
-  
-  std::vector<unsigned int> ns_save = 
-    Rcpp::as<std::vector<unsigned int> >(lst["n_save"]); 
 
-  std::vector<unsigned int> ns_warmup2 = 
-    Rcpp::as<std::vector<unsigned int> >(lst["warmup2"]); 
+  std::vector<unsigned int> ns_save =
+    Rcpp::as<std::vector<unsigned int> >(lst["n_save"]);
 
-  std::vector<unsigned int> ns_kept(ns_save); 
-  for (size_t i = 0; i < ns_kept.size(); i++) 
-    ns_kept[i] -= ns_warmup2[i]; 
+  std::vector<unsigned int> ns_warmup2 =
+    Rcpp::as<std::vector<unsigned int> >(lst["warmup2"]);
 
-  unsigned int n_samples = ns_kept[0]; 
+  std::vector<unsigned int> ns_kept(ns_save);
+  for (size_t i = 0; i < ns_kept.size(); i++)
+    ns_kept[i] -= ns_warmup2[i];
+
+  unsigned int n_samples = ns_kept[0];
   for (size_t chain = 1; chain < m; chain++) {
-    n_samples = std::min(n_samples, ns_kept[chain]); 
+    n_samples = std::min(n_samples, ns_kept[chain]);
   }
 
   using std::vector;
@@ -308,11 +308,11 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
     rstan::autocovariance(sim, chain, n, acov_chain);
     acov.push_back(acov_chain);
   }
-  
+
   vector<double> chain_mean;
   vector<double> chain_var;
   for (size_t chain = 0; chain < m; chain++) {
-    unsigned int n_kept_samples = ns_kept[chain]; 
+    unsigned int n_kept_samples = ns_kept[chain];
     chain_mean.push_back(rstan::get_chain_mean(sim,chain,n));
     chain_var.push_back(acov[chain][0]*n_kept_samples/(n_kept_samples-1));
   }
@@ -330,7 +330,7 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
     if (rho_hat >= 0)
       rho_hat_t.push_back(rho_hat);
   }
-  
+
   double ess = m*n_samples;
   if (rho_hat_t.size() > 0) {
     ess /= 1 + 2 * stan::math::sum(rho_hat_t);
@@ -339,15 +339,15 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
   PROTECT(__sexp_result = Rcpp::wrap(ess));
   UNPROTECT(1);
   return __sexp_result;
-  END_RCPP 
+  END_RCPP
 }
 
 /*
- * Wrap the autocovariance function in Stan 
+ * Wrap the autocovariance function in Stan
  * @param v: a vector in R
- */ 
+ */
 SEXP stan_prob_autocovariance(SEXP v) {
-  BEGIN_RCPP 
+  BEGIN_RCPP
   std::vector<double> dv = Rcpp::as<std::vector<double> >(v);
   std::vector<double> acov;
   stan::prob::autocovariance(dv, acov);
@@ -356,19 +356,19 @@ SEXP stan_prob_autocovariance(SEXP v) {
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}
 
 /**
- * Returns the effective sample size for samples 
- * of 2-d without warmup, similar to effective_sample_size 
+ * Returns the effective sample size for samples
+ * of 2-d without warmup, similar to effective_sample_size
  * but with simpler input of samples.
  *
- * @param sims A 2-d array of # iter * # chains _without_ warmup for 
- *  one parameter 
+ * @param sims A 2-d array of # iter * # chains _without_ warmup for
+ *  one parameter
  * @return The effective sample size.
- */ 
-SEXP effective_sample_size2(SEXP sims) { 
-  BEGIN_RCPP 
+ */
+SEXP effective_sample_size2(SEXP sims) {
+  BEGIN_RCPP
   Rcpp::NumericMatrix nm(sims);
   unsigned int m(nm.ncol());
   unsigned int n_samples(nm.nrow());
@@ -389,7 +389,7 @@ SEXP effective_sample_size2(SEXP sims) {
   for (size_t chain = 0; chain < m; chain++) {
     chain_var.push_back(acov[chain][0]*n_samples/(n_samples-1));
   }
-  
+
   double mean_var = stan::math::mean(chain_var);
   double var_plus = mean_var*(n_samples-1)/n_samples;
   if (m > 1) var_plus += stan::math::variance(chain_mean);
@@ -404,7 +404,7 @@ SEXP effective_sample_size2(SEXP sims) {
     if (rho_hat >= 0)
       rho_hat_t.push_back(rho_hat);
   }
-  
+
   double ess = m*n_samples;
   if (rho_hat_t.size() > 0) {
     ess /= 1 + 2 * stan::math::sum(rho_hat_t);
@@ -414,23 +414,23 @@ SEXP effective_sample_size2(SEXP sims) {
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}
 
 
 /**
  *
  * Return the split rhat as split_potential_scale_reduction.
- * Here the input is a two-d array: # iters * # chains 
- * 
+ * Here the input is a two-d array: # iters * # chains
+ *
  * @param[in] sims Simulation samples of several chains for one parameters,
- *  no warmup samples are included 
+ *  no warmup samples are included
  * @return split R hat.
- */ 
+ */
 SEXP split_potential_scale_reduction2(SEXP sims_) {
-  BEGIN_RCPP 
+  BEGIN_RCPP
   Rcpp::NumericMatrix nm(sims_);
   unsigned int n_chains = nm.ncol();
-  unsigned int n_samples = nm.nrow(); 
+  unsigned int n_samples = nm.nrow();
   if (n_samples % 2 == 1)
     n_samples--;
 
@@ -440,19 +440,19 @@ SEXP split_potential_scale_reduction2(SEXP sims_) {
   for (size_t chain = 0; chain < n_chains; chain++) {
     std::vector<double> split_chain(n_samples/2);
     Rcpp::NumericMatrix::Column samples = nm(Rcpp::_, chain);
-    split_chain.assign(samples.begin(), 
+    split_chain.assign(samples.begin(),
                        samples.begin() + n_samples/2);
     split_chain_mean.push_back(stan::math::mean(split_chain));
     split_chain_var.push_back(stan::math::variance(split_chain));
-    split_chain.assign(samples.end()-n_samples/2, 
+    split_chain.assign(samples.end()-n_samples/2,
                        samples.end());
     split_chain_mean.push_back(stan::math::mean(split_chain));
     split_chain_var.push_back(stan::math::variance(split_chain));
-  } 
+  }
   // copied and pasted from split_potential_scale_reduction
   double var_between = n_samples/2 * stan::math::variance(split_chain_mean);
   double var_within = stan::math::mean(split_chain_var);
-  
+
   // rewrote [(n-1)*W/n + B/n]/W as (n-1+ B/W)/n
   double srhat = sqrt((var_between/var_within + n_samples/2 -1)/(n_samples/2));
 
@@ -461,62 +461,62 @@ SEXP split_potential_scale_reduction2(SEXP sims_) {
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}
 
-/** 
+/**
  * Return the split potential scale reduction (split R hat)
  * for the specified parameter.
  *
  * Current implementation takes the minimum number of samples
  * across chains as the number of samples per chain.
- * 
+ *
  * @param[in] n Parameter index
- * 
+ *
  * @return split R hat.
  */
-SEXP split_potential_scale_reduction(SEXP sim, SEXP n_) { 
+SEXP split_potential_scale_reduction(SEXP sim, SEXP n_) {
 
-  BEGIN_RCPP 
-  rstan::validate_sim(sim); 
-  Rcpp::List lst(sim); 
-  unsigned int n = Rcpp::as<unsigned int>(n_); 
-  // Rcpp::Rcout << "n=" << n << std::endl; 
-  unsigned int n_chains(rstan::num_chains(sim)); 
-  // Rcpp::Rcout << "n_chains=" << n_chains << std::endl; 
+  BEGIN_RCPP
+  rstan::validate_sim(sim);
+  Rcpp::List lst(sim);
+  unsigned int n = Rcpp::as<unsigned int>(n_);
+  // Rcpp::Rcout << "n=" << n << std::endl;
+  unsigned int n_chains(rstan::num_chains(sim));
+  // Rcpp::Rcout << "n_chains=" << n_chains << std::endl;
 
-  std::vector<unsigned int> ns_save = 
-    Rcpp::as<std::vector<unsigned int> >(lst["n_save"]); 
+  std::vector<unsigned int> ns_save =
+    Rcpp::as<std::vector<unsigned int> >(lst["n_save"]);
 
-  std::vector<unsigned int> ns_warmup2 = 
-    Rcpp::as<std::vector<unsigned int> >(lst["warmup2"]); 
+  std::vector<unsigned int> ns_warmup2 =
+    Rcpp::as<std::vector<unsigned int> >(lst["warmup2"]);
 
-  std::vector<unsigned int> ns_kept(ns_save); 
-  for (size_t i = 0; i < ns_kept.size(); i++) 
-    ns_kept[i] -= ns_warmup2[i]; 
+  std::vector<unsigned int> ns_kept(ns_save);
+  for (size_t i = 0; i < ns_kept.size(); i++)
+    ns_kept[i] -= ns_warmup2[i];
 
-  unsigned int n_samples = ns_kept[0]; 
+  unsigned int n_samples = ns_kept[0];
   for (size_t chain = 1; chain < n_chains; chain++) {
-    n_samples = std::min(n_samples, ns_kept[chain]); 
+    n_samples = std::min(n_samples, ns_kept[chain]);
   }
 
   if (n_samples % 2 == 1)
     n_samples--;
-  
+
   std::vector<double> split_chain_mean;
   std::vector<double> split_chain_var;
 
   for (size_t chain = 0; chain < n_chains; chain++) {
     std::vector<double> samples; // (n_samples);
     rstan::get_kept_samples(sim, chain, n, samples);
-    // Rcpp::Rcout << samples[0] << ", " << samples.size() << std::endl; 
-    
+    // Rcpp::Rcout << samples[0] << ", " << samples.size() << std::endl;
+
     std::vector<double> split_chain(n_samples/2);
     split_chain.assign(samples.begin(),
                        samples.begin()+n_samples/2);
     split_chain_mean.push_back(stan::math::mean(split_chain));
     split_chain_var.push_back(stan::math::variance(split_chain));
-    
-    split_chain.assign(samples.end()-n_samples/2, 
+
+    split_chain.assign(samples.end()-n_samples/2,
                        samples.end());
     split_chain_mean.push_back(stan::math::mean(split_chain));
     split_chain_var.push_back(stan::math::variance(split_chain));
@@ -524,63 +524,63 @@ SEXP split_potential_scale_reduction(SEXP sim, SEXP n_) {
 
   double var_between = n_samples/2 * stan::math::variance(split_chain_mean);
   double var_within = stan::math::mean(split_chain_var);
-  
+
   // rewrote [(n-1)*W/n + B/n]/W as (n-1+ B/W)/n
   double srhat = sqrt((var_between/var_within + n_samples/2 -1)/(n_samples/2));
   SEXP __sexp_result;
   PROTECT(__sexp_result = Rcpp::wrap(srhat));
   UNPROTECT(1);
   return __sexp_result;
-  END_RCPP 
+  END_RCPP
 }
 
 /*
- * Obtain a permutation of size n. 
- * see <code>permutation</code> in <code>mcmc::chains.hpp</code>. 
+ * Obtain a permutation of size n.
+ * see <code>permutation</code> in <code>mcmc::chains.hpp</code>.
  *
- * @param conf an R named list contains elements: n, chains, seed, chain_id. 
- * 
+ * @param conf an R named list contains elements: n, chains, seed, chain_id.
+ *
  * @return A permutation of length 'n' starting from 0.
- */ 
-SEXP seq_permutation(SEXP conf) { 
-  BEGIN_RCPP 
-  Rcpp::List lst(conf); 
+ */
+SEXP seq_permutation(SEXP conf) {
+  BEGIN_RCPP
+  Rcpp::List lst(conf);
   rstan::perm_args args(lst);
-  boost::uintmax_t DISCARD_STRIDE = static_cast<boost::uintmax_t>(1) << 50; 
+  boost::uintmax_t DISCARD_STRIDE = static_cast<boost::uintmax_t>(1) << 50;
   int n = args.get_n();
-  int cid = args.get_chain_id() + args.get_chains(); 
-  typedef boost::random::ecuyer1988 RNG;   
-  RNG rng(args.get_seed()); 
+  int cid = args.get_chain_id() + args.get_chains();
+  typedef boost::random::ecuyer1988 RNG;
+  RNG rng(args.get_seed());
   rng.discard(DISCARD_STRIDE * (cid - 1));
-  Rcpp::IntegerVector x(n); 
+  Rcpp::IntegerVector x(n);
   for (int i = 0; i < n; ++i)
     x[i] = i;
-  if (n < 2) return x; 
+  if (n < 2) return x;
   for (int i = n; --i != 0; ) {
     boost::random::uniform_int_distribution<int> uid(0, i);
     int j = uid(rng);
     int temp = x[i];
     x[i] = x[j];
     x[j] = temp;
-  } 
+  }
   SEXP __sexp_result;
   PROTECT(__sexp_result = Rcpp::wrap(x));
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}
 
 /**
- *  Read comments 
+ *  Read comments
  *  @param file The filename (a character string in R)
- *  @param n Maximum number of lines (an integer in R): -1 for all 
+ *  @param n Maximum number of lines (an integer in R): -1 for all
  *  @returns A character vector each element of which is a line of comments
  *  begining with `#`
- */ 
+ */
 SEXP CPP_read_comments(SEXP file, SEXP n) {
-  BEGIN_RCPP 
+  BEGIN_RCPP
   std::string filename = Rcpp::as<std::string>(file);
-  int n2 = Rcpp::as<int>(n); 
+  int n2 = Rcpp::as<int>(n);
   size_t n3 = (0 <= n2) ? static_cast<size_t>(n2) : std::numeric_limits<size_t>::max();
   std::vector<std::string> comments;
   rstan::read_comments0(filename, n3, comments);
@@ -589,4 +589,4 @@ SEXP CPP_read_comments(SEXP file, SEXP n) {
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}

--- a/rstan/rstan/src/gm__ast_def.cpp
+++ b/rstan/rstan/src/gm__ast_def.cpp
@@ -1,1 +1,1 @@
-#include <stan/gm/ast_def.cpp> 
+#include <stan/gm/ast_def.cpp>

--- a/rstan/rstan/src/gm__grammars__expression_grammar_inst.cpp
+++ b/rstan/rstan/src/gm__grammars__expression_grammar_inst.cpp
@@ -1,2 +1,2 @@
-#include <stan/gm/grammars/expression_grammar_inst.cpp> 
+#include <stan/gm/grammars/expression_grammar_inst.cpp>
 

--- a/rstan/rstan/src/gm__grammars__term_grammar_inst.cpp
+++ b/rstan/rstan/src/gm__grammars__term_grammar_inst.cpp
@@ -1,1 +1,1 @@
-#include <stan/gm/grammars/term_grammar_inst.cpp> 
+#include <stan/gm/grammars/term_grammar_inst.cpp>

--- a/rstan/rstan/src/init.cpp
+++ b/rstan/rstan/src/init.cpp
@@ -1,10 +1,10 @@
 /*
- * To register the functions implemented in C++, see 
+ * To register the functions implemented in C++, see
  * http://cran.r-project.org/doc/manuals/R-exts.html#Registering-native-routines
  *
  * But it seems not to work as it is supposed to be in that
- * even they are still working if not registered, which 
- * is not understood. 
+ * even they are still working if not registered, which
+ * is not understood.
  */
 #include <R.h>
 #include <Rinternals.h>
@@ -15,16 +15,16 @@
 #ifdef __cplusplus
 extern "C"  {
 #endif
-SEXP effective_sample_size(SEXP sim, SEXP n_); 
+SEXP effective_sample_size(SEXP sim, SEXP n_);
 SEXP effective_sample_size2(SEXP sims);
-SEXP split_potential_scale_reduction(SEXP sim, SEXP n_); 
+SEXP split_potential_scale_reduction(SEXP sim, SEXP n_);
 SEXP split_potential_scale_reduction2(SEXP sims_);
-SEXP seq_permutation(SEXP conf);  
+SEXP seq_permutation(SEXP conf);
 SEXP CPP_read_comments(SEXP file, SEXP n);
 SEXP stan_prob_autocovariance(SEXP v);
 SEXP is_Null_NS(SEXP ns);
 SEXP CPP_stanc240(SEXP model_stancode, SEXP model_name);
-SEXP CPP_stan_version(); 
+SEXP CPP_stan_version();
 #ifdef __cplusplus
 }
 #endif
@@ -51,11 +51,11 @@ extern "C"  {
 void attribute_visible R_init_rstan(DllInfo *dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
-  // The call to R_useDynamicSymbols indicates that if the correct C 
+  // The call to R_useDynamicSymbols indicates that if the correct C
   // entry point is not found in the shared library, then an error
   // should be signaled.  Currently, the default
   // behavior in R is to search all other loaded shared libraries for the
-  // symbol, which is fairly dangerous behavior.  If you have registered 
+  // symbol, which is fairly dangerous behavior.  If you have registered
   // all routines in your library, then you should set this to FALSE
   // as done in the stats package. [copied from `R Programming for
   // Bioinformatics' // by Robert Gentleman]

--- a/rstan/rstan/src/misc.cpp
+++ b/rstan/rstan/src/misc.cpp
@@ -1,4 +1,4 @@
-// #include <stan/mcmc/chains.hpp> 
+// #include <stan/mcmc/chains.hpp>
 
 #include <R.h>
 #include <Rinternals.h>
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-extern SEXP is_Null_NS(SEXP ns); 
+extern SEXP is_Null_NS(SEXP ns);
 
 #ifdef __cplusplus
 }
@@ -15,11 +15,11 @@ extern SEXP is_Null_NS(SEXP ns);
 
 
 /*
- * Tell if it is a NULL native symbol. 
+ * Tell if it is a NULL native symbol.
  * This function mainly used to tell if a function created by cxxfunction of R
  * package inline points to a NULL address, which would happen when it is
- * deserialized (that is, loaded from what was saved previously by using R's save). 
- *  
+ * deserialized (that is, loaded from what was saved previously by using R's save).
+ *
  */
 SEXP is_Null_NS(SEXP ns) {
   SEXP ans;

--- a/rstan/rstan/src/stanc.cpp
+++ b/rstan/rstan/src/stanc.cpp
@@ -10,14 +10,14 @@
 #include <string>
 
 #include <Rcpp.h>
-#include <rstan/io/r_ostream.hpp> 
+#include <rstan/io/r_ostream.hpp>
 
 RcppExport SEXP CPP_stanc240(SEXP model_stancode, SEXP model_name);
-RcppExport SEXP CPP_stan_version(); 
+RcppExport SEXP CPP_stan_version();
 
 SEXP CPP_stan_version() {
   BEGIN_RCPP
-  std::string stan_version 
+  std::string stan_version
     = stan::MAJOR_VERSION + "." +
       stan::MINOR_VERSION + "." +
       stan::PATCH_VERSION;
@@ -26,41 +26,41 @@ SEXP CPP_stan_version() {
   UNPROTECT(1);
   return __sexp_result;
   END_RCPP
-} 
+}
 
-SEXP CPP_stanc240(SEXP model_stancode, SEXP model_name) { 
+SEXP CPP_stanc240(SEXP model_stancode, SEXP model_name) {
   BEGIN_RCPP;
   static const int SUCCESS_RC = 0;
   static const int EXCEPTION_RC = -1;
   static const int PARSE_FAIL_RC = -2;
-  
+
   /*
-  std::string stan_version 
+  std::string stan_version
     = stan::MAJOR_VERSION + "." +
       stan::MINOR_VERSION + "." +
       stan::PATCH_VERSION;
   */
 
-  std::string mcode_ = Rcpp::as<std::string>(model_stancode); 
-  std::string mname_ = Rcpp::as<std::string>(model_name); 
-   
+  std::string mcode_ = Rcpp::as<std::string>(model_stancode);
+  std::string mname_ = Rcpp::as<std::string>(model_name);
+
   std::stringstream out;
-  std::istringstream in(mcode_); 
+  std::istringstream in(mcode_);
   try {
     bool valid_model
       = stan::gm::compile(&rstan::io::rcerr,in,out,mname_);
     if (!valid_model) {
-      return Rcpp::List::create(Rcpp::Named("status") = PARSE_FAIL_RC); 
+      return Rcpp::List::create(Rcpp::Named("status") = PARSE_FAIL_RC);
 
     }
   } catch(const std::exception& e) {
-    // REprintf("\nERROR PARSING\n %s\n", e.what()); 
+    // REprintf("\nERROR PARSING\n %s\n", e.what());
     return Rcpp::List::create(Rcpp::Named("status") = EXCEPTION_RC,
-                              Rcpp::Named("msg") = Rcpp::wrap(e.what())); 
+                              Rcpp::Named("msg") = Rcpp::wrap(e.what()));
   }
 
-  Rcpp::List lst = 
-    Rcpp::List::create(Rcpp::Named("status") = SUCCESS_RC, 
+  Rcpp::List lst =
+    Rcpp::List::create(Rcpp::Named("status") = SUCCESS_RC,
                        Rcpp::Named("model_cppname") = mname_,
                        Rcpp::Named("cppcode") = out.str());
   SEXP __sexp_result;


### PR DESCRIPTION
Helps when using diff to compare code. Also, from the Google C++ Style guide:
"Never put trailing whitespace at the end of a line."
https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml

To do this I just ran `find . -type f | xargs sed -i 's/[ \t]*$//'` in `rstan/rstan/inst/include/rstan`

What motivates this is my frequent `diff`ing RStan's stan_fit.hpp and PyStan's stan_fit.hpp.
