### PR TITLE
Corrects bug when processing 1x1 matrices in seq_array_ind

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -713,16 +713,17 @@ seq_array_ind <- function(d, col_major = FALSE) {
   if (length(d) == 0L)
     return(numeric(0L)) 
 
-  ## Handles one by one matrices
-  if (all(d == 1L))
-    return(array(1L, dim = d))
-
   total <- prod(d) 
   len <- length(d) 
   if (len == 1L)
     return(array(1:total, dim = c(total, 1)))
 
   res <- array(1L, dim = c(total, len)) 
+
+  # Handle cases like 1x1 matrices
+  if (total == 1)
+    return(res)
+  
   jidx <- if (col_major) 1L:len else len:1L
   for (i in 2L:total) {
     res[i, ] <- res[i - 1, ]


### PR DESCRIPTION
Hello,

This patch corrects a bug that occurred while I was trying to estimate a model with `optimizing`. One by one matrices produce an error in seq_array_ind at the end of the fitting procedure.
