### PR TITLE
Do not always reinstall Rcpp and friends if installed

### DIFF
--- a/rstan/install.R
+++ b/rstan/install.R
@@ -3,11 +3,19 @@ install_rstan <- function() {
   on.exit(Sys.unsetenv("R_MAKEVARS_USER"))
   on.exit(Sys.unsetenv("R_MAKEVARS_SITE"), add = TRUE)
 
+  opts <- options(repos = c(
+    getOption("repos"), 
+    rstan = "http://rstan.org/repo/",
+    CRAN = "http://cran.rstudio.com"
+  ))
+  on.exit(options(opts), add = TRUE)
   try(remove.packages("rstan"), silent = TRUE)
   Sys.setenv(R_MAKEVARS_USER = "foobar")
   Sys.setenv(R_MAKEVARS_SITE = "foobar")
-  install.packages(c("inline", "BH", "RcppEigen"))
-  install.packages("Rcpp", type = "source")
+  for (pkg in c("inline", "BH", "RcppEigen")) {
+    if (!requireNamespace(pkg)) install.packages(pkg)
+  }
+  if (!requireNamespace("Rcpp")) install.packages("Rcpp", type = "source")
   library(inline) 
   library(Rcpp)
   src <- ' 
@@ -20,8 +28,6 @@ install_rstan <- function() {
   test <- try(hellofun())
   if(inherits(test, "try-error")) stop("hello world failed; ask for help on Rcpp list")
 
-  options(repos = c(getOption("repos"), 
-          rstan = "http://rstan.org/repo/"))
   install.packages("rstan", type = 'source')
   library(rstan)
   set_cppo("fast")
@@ -29,5 +35,4 @@ install_rstan <- function() {
     cat('\nCC=clang', 'CXX=clang++ -arch x86_64 -ftemplate-depth-256', 
         file = "~/.R/Makevars", sep = "\n", append = TRUE)
   }
-  return(invisible(NULL))
 }


### PR DESCRIPTION
- I set a default CRAN mirror cran.rstudio.com as the fallback mirror; this will make it possible to fully automate the installation, otherwise R will pop up a menu asking for the CRAN mirror, which is not good for installing rstan on headless servers or automated testing
- I used `requireNamespace()` to check if Rcpp and friends have been installed, so that we do not have to reinstall them every single time we run this script