### PR TITLE
rstan.R/stanc.R: use message instead of cat for model translation & compilation

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -45,8 +45,8 @@ stan_model <- function(file,
                get_Rcpp_module_def_code(model_cppname), 
                sep = '')  
 
-  cat("COMPILING THE C++ CODE FOR MODEL '", model_name, "' NOW.\n", sep = '') 
-  if (verbose) cat(system_info(), "\n")
+  message("COMPILING THE C++ CODE FOR MODEL '", model_name, "' NOW.")
+  if (verbose) message(system_info())
   if (!is.null(boost_lib)) { 
     old.boost_lib <- rstan_options(boost_lib = boost_lib) 
     on.exit(rstan_options(boost_lib = old.boost_lib)) 

--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -9,7 +9,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model", verbose = FA
   model_code <- get_model_strcode(file, model_code)  
   if (missing(model_name) || is.null(model_name)) 
     model_name <- attr(model_code, "model_name2") 
-  cat("\nTRANSLATING MODEL '", model_name, "' FROM Stan CODE TO C++ CODE NOW.\n", sep = '')
+  message("\nTRANSLATING MODEL '", model_name, "' FROM Stan CODE TO C++ CODE NOW.")
   SUCCESS_RC <- 0 
   EXCEPTION_RC <- -1
   PARSE_FAIL_RC <- -2 
@@ -45,7 +45,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model", verbose = FA
   } 
 
   if (r$status == SUCCESS_RC && verbose)
-    cat("successful in parsing the Stan model '", model_name, "'.\n", sep = '')
+    message("successful in parsing the Stan model '", model_name, "'.")
 
   r$status = !as.logical(r$status)
   invisible(r)


### PR DESCRIPTION
- `message` can be silenced using `suppressMessages`
- This allows better integration with, e.g., `knitr` (see http://yihui.name/knitr/demo/output/)
