### PR TITLE
Feature/return wall time

### DIFF
--- a/rstan/rstan/NAMESPACE
+++ b/rstan/rstan/NAMESPACE
@@ -41,6 +41,7 @@ exportMethods(
   get_sampler_params,
   get_logposterior, 
   get_posterior_mean,
+  get_elapsed_time,
   get_stanmodel
 )
 S3method(print, stanfit)

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1511,3 +1511,24 @@ is_arg_recognizable <- function(x, y, pre_msg = '', post_msg = '', ...) {
   TRUE
 }
 
+get_time_from_csv <- function(tlines) {
+  # get the warmup time and sample time from the commented lines
+  # about time in the CSV files
+  # Args:
+  #  tlines: character vector of length 3 (or 2 since the last one is not used)
+  #          from the CSV File. For example, it could be
+  #          # Elapsed Time: 0.005308 seconds (Warm-up)
+  #                          0.003964 seconds (Sampling)
+  #                          0.009272 seconds (Total)
+  t <- rep(NA, 2)
+  names(t) <- c("warmup", "sample")
+  if (length(tlines) < 2) return(t)
+  warmupt <- gsub(".*#\\s*Elapsed.*:\\s*", "", tlines[1])
+  warmupt <- gsub("\\s*seconds.*$", "", warmupt)
+  samplet <- gsub(".*#\\s*", "", tlines[2])
+  samplet <- gsub("\\s*seconds.*$", "", samplet)
+  t[1] <- as.double(warmupt)
+  t[2] <- as.double(samplet)
+  t
+}
+

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -86,6 +86,7 @@ parse_stancsv_comments <- function(comments) {
   names(values) <- names0;
 
   add_lst <- list(adaptation_info = adaptation_info,
+                  has_time = has_time,
                   time_info = time_info)
 
   sampler_t <- NULL
@@ -186,6 +187,8 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     attr(samples[[i]], "args") <- 
       list(sampler_t = cs_lst2[[i]]$sampler_t,
            chain_id = cs_lst2[[i]]$chain_id)
+    if (cs_lst2[[i]]$has_time)
+      attr(samples[[i]], "elapsed_time") <- get_time_from_csv(cs_lst2[[i]]$time_info)
   } 
 
   save_warmup <- sapply(cs_lst2, function(i) i$save_warmup)

--- a/rstan/rstan/R/stanfit-class.R
+++ b/rstan/rstan/R/stanfit-class.R
@@ -325,6 +325,25 @@ setMethod("get_sampler_params",
                              SIMPLIFY = FALSE, USE.NAMES = FALSE)) 
           }) 
 
+setGeneric(name = 'get_elapsed_time',
+           def = function(object, ...) { standardGeneric("get_elapsed_time")})
+
+setMethod("get_elapsed_time",
+          definition = function(object, inc_warmup = TRUE) {
+            if (object@mode == 1L) {
+              cat("Stan model '", object@model_name, "' is of mode 'test_grad';\n",
+                  "sampling is not conducted.\n", sep = '')
+              return(invisible(NULL))
+            } else if (object@mode == 2L) {
+              cat("Stan model '", object@model_name, "' does not contain samples.\n", sep = '')
+              return(invisible(NULL))
+            }
+
+            ltime <- lapply(object@sim$samples,
+                            function(x) attr(x, "elapsed_time"))
+            do.call(rbind, ltime)
+          })
+
 setGeneric(name = 'get_posterior_mean', 
            def = function(object, ...) { standardGeneric("get_posterior_mean")}) 
 

--- a/rstan/rstan/R/stanfit-class.R
+++ b/rstan/rstan/R/stanfit-class.R
@@ -342,6 +342,7 @@ setMethod("get_elapsed_time",
             ltime <- lapply(object@sim$samples,
                             function(x) attr(x, "elapsed_time"))
             t <- do.call(rbind, ltime)
+            if (is.null(t)) return(t)
             cids <- sapply(object@stan_args, function(x) x$chain_id)
             rownames(t) <- paste0("chain:", cids)
             t

--- a/rstan/rstan/R/stanfit-class.R
+++ b/rstan/rstan/R/stanfit-class.R
@@ -341,7 +341,10 @@ setMethod("get_elapsed_time",
 
             ltime <- lapply(object@sim$samples,
                             function(x) attr(x, "elapsed_time"))
-            do.call(rbind, ltime)
+            t <- do.call(rbind, ltime)
+            cids <- sapply(object@stan_args, function(x) x$chain_id)
+            rownames(t) <- paste0("chain:", cids)
+            t
           })
 
 setGeneric(name = 'get_posterior_mean', 

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -164,8 +164,32 @@ setMethod("sampling", "stanmodel",
                    algorithm = c("NUTS", "HMC", "Fixed_param"), #, "Metropolis"), 
                    control = NULL, cores = getOption("mc.cores", 1L), 
                    open_progress = interactive() && !isatty(stdout()), ...) {
-            
-            if(cores > 1) {
+
+            if (check_data) {
+              data <- try(force(data))
+              if (is(data, "try-error")) {
+                message("failed to evaluate the data; sampling not done")
+                return(invisible(new_empty_stanfit(object)))
+              }
+              # allow data to be specified as a vector of character string
+              if (is.character(data)) {
+                data <- try(mklist(data))
+                if (is(data, "try-error")) {
+                  message("failed to create the data; sampling not done")
+                  return(invisible(new_empty_stanfit(object)))
+                }
+              }
+              # check data and preprocess
+              if (!missing(data) && length(data) > 0) {
+                data <- try(data_preprocess(data))
+                if (is(data, "try-error")) {
+                  message("failed to preprocess the data; sampling not done")
+                  return(invisible(new_empty_stanfit(object)))
+                }
+              } else data <- list()
+            }
+
+            if (chains > 1 && cores > 1) {
               dotlist <- c(sapply(ls(), simplify = FALSE, FUN = get,
                                   envir = environment()), list(...))
               dotlist$chains <- 1L
@@ -206,30 +230,6 @@ setMethod("sampling", "stanmodel",
             model_cppname <- object@model_cpp$model_cppname 
             mod <- get("module", envir = object@dso@.CXXDSOMISC, inherits = FALSE) 
             stan_fit_cpp_module <- eval(call("$", mod, paste('stan_fit4', model_cppname, sep = ''))) 
-            if (check_data) { 
-              data <- try(force(data))
-              if (is(data, "try-error")) {
-                message("failed to evaluate the data; sampling not done")
-                return(invisible(new_empty_stanfit(object)))
-              }
-              # allow data to be specified as a vector of character string 
-              if (is.character(data)) {
-                data <- try(mklist(data))
-                if (is(data, "try-error")) {
-                  message("failed to create the data; sampling not done") 
-                  return(invisible(new_empty_stanfit(object)))
-                }
-              }
-              # check data and preprocess
-              if (!missing(data) && length(data) > 0) {
-                data <- try(data_preprocess(data))
-                if (is(data, "try-error")) {
-                  message("failed to preprocess the data; sampling not done") 
-                  return(invisible(new_empty_stanfit(object)))
-                }
-              } else data <- list()
-            } 
-
             sampler <- try(new(stan_fit_cpp_module, data, object@dso@.CXXDSOMISC$cxxfun)) 
             sfmiscenv <- new.env()
             if (is(sampler, "try-error")) {
@@ -276,7 +276,8 @@ setMethod("sampling", "stanmodel",
 
             for (i in 1:chains) {
               if (is.null(dots$refresh) || dots$refresh > 0) 
-                cat('\n', mode, " FOR MODEL '", object@model_name, "' NOW (CHAIN ", i, ").\n", sep = '')
+                cat('\n', mode, " FOR MODEL '", object@model_name, 
+                    "' NOW (CHAIN ", args_list[[i]]$chain_id, ").\n", sep = '')
               samples_i <- try(sampler$call_sampler(args_list[[i]])) 
               if (is(samples_i, "try-error") || is.null(samples_i)) {
                 message("error occurred during calling the sampler; sampling not done") 

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -194,6 +194,8 @@ setMethod("sampling", "stanmodel",
                                   envir = environment()), list(...))
               dotlist$chains <- 1L
               dotlist$cores <- 1L
+              dotlist$data <- data
+              dotlist$check_data <- FALSE
               if(open_progress) {
                 sinkfile <- paste0(tempfile(), "_StanProgress.txt")
                 cat("Refresh to see progress\n", file = sinkfile)

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -165,7 +165,7 @@ setMethod("sampling", "stanmodel",
                    control = NULL, cores = getOption("mc.cores", 1L), 
                    open_progress = interactive() && !isatty(stdout()), ...) {
 
-            if (check_data) {
+            if (check_data || is.character(data)) {
               data <- try(force(data))
               if (is(data, "try-error")) {
                 message("failed to evaluate the data; sampling not done")

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -165,21 +165,21 @@ setMethod("sampling", "stanmodel",
                    control = NULL, cores = getOption("mc.cores", 1L), 
                    open_progress = interactive() && !isatty(stdout()), ...) {
 
-            if (check_data || is.character(data)) {
+            # allow data to be specified as a vector of character string
+            if (is.character(data)) {
+              data <- try(mklist(data))
+              if (is(data, "try-error")) {
+                message("failed to create the data; sampling not done")
+                return(invisible(new_empty_stanfit(object)))
+              }
+            }
+            # check data and preprocess
+            if (check_data) {
               data <- try(force(data))
               if (is(data, "try-error")) {
                 message("failed to evaluate the data; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
               }
-              # allow data to be specified as a vector of character string
-              if (is.character(data)) {
-                data <- try(mklist(data))
-                if (is(data, "try-error")) {
-                  message("failed to create the data; sampling not done")
-                  return(invisible(new_empty_stanfit(object)))
-                }
-              }
-              # check data and preprocess
               if (!missing(data) && length(data) > 0) {
                 data <- try(data_preprocess(data))
                 if (is(data, "try-error")) {
@@ -195,7 +195,6 @@ setMethod("sampling", "stanmodel",
               dotlist$chains <- 1L
               dotlist$cores <- 1L
               dotlist$data <- data
-              dotlist$check_data <- FALSE
               if(open_progress && 
                  !identical(browser <- getOption("browser"), "false")) {
                 sinkfile <- paste0(tempfile(), "_StanProgress.txt")

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -220,9 +220,9 @@ setMethod("sampling", "stanmodel",
               nfits <- parallel::parLapply(cl, X = 1:chains, fun = callFun)
               if(all(sapply(nfits, is, class2 = "stanfit")) &&
                  all(sapply(nfits, FUN = function(x) x@mode == 0))) {
-                nfits <- sflist2stanfit(nfits)
+                 return(sflist2stanfit(nfits))
               }
-              return(nfits)
+              return(nfits[[1]])
             }
             dots <- list(...)
             check_unknown_args <- dots$check_unknown_args

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -558,6 +558,9 @@ namespace rstan {
       holder.attr("mean_pars") = mean_pars;
       holder.attr("mean_lp__") = mean_lp;
       holder.attr("adaptation_info") = adaptation_info;
+      holder.attr("elapsed_time") =
+        Rcpp::NumericVector::create(Rcpp::_["warmup"] = warmDeltaT,
+                                    Rcpp::_["sample"] = sampleDeltaT);
 
       Rcpp::List slst(sample_recorder.sampler_values_.x().begin()+1,
                       sample_recorder.sampler_values_.x().end());

--- a/rstan/rstan/inst/unitTests/runit.test.stan_csv.R
+++ b/rstan/rstan/inst/unitTests/runit.test.stan_csv.R
@@ -60,10 +60,11 @@ test_parse_stancsv_comments3 <- function() {
   lst <- rstan:::parse_stancsv_comments(comments)
   checkEquals(lst$chain_id, 0)
   existence <- c("seed", "chain_id", "iter", "warmup", "thin", 
-                 "save_warmup", "stepsize",
+                 "save_warmup", "stepsize", "time_info", "has_time",
                  "adaptation_info") %in% names(lst)
   checkTrue(all(existence))
   checkEquals(lst$seed, "3086139456")
   checkEquals(lst$stepsize, 1)
   checkEquals(lst$sampler_t, "NUTS(diag_e)")
+  checkEquals(lst$has_time, TRUE)
 }

--- a/rstan/rstan/man/rstan-internal.Rd
+++ b/rstan/rstan/man/rstan-internal.Rd
@@ -5,6 +5,7 @@
 \alias{get_adaptation_info,ANY-method}
 \alias{get_sampler_params,ANY-method}
 \alias{get_posterior_mean,ANY-method}
+\alias{get_elapsed_time,ANY-method}
 \alias{get_num_upars,ANY-method}
 \alias{log_prob,ANY-method}
 \alias{grad_log_prob,ANY-method}

--- a/rstan/rstan/man/stanfit-class.Rd
+++ b/rstan/rstan/man/stanfit-class.Rd
@@ -140,7 +140,7 @@
       get the posterior mean for parameters of interest (using \code{pars}
       to specify) among \emph{all} parameters.} 
     \item{\code{get_elapsed_time}}{\code{signature(object = "stanfit")}:
-      get the warmup time and sample time spent to draw the samples.
+      get the warmup time and sample time in seconds spent to draw the samples.
       A matrix of two columns is returned: each row has the time information
       for one chain.}
     \item{\code{get_stancode}}{\code{signature(object = "stanfit")}:

--- a/rstan/rstan/man/stanfit-class.Rd
+++ b/rstan/rstan/man/stanfit-class.Rd
@@ -21,6 +21,8 @@
 \alias{get_inits}
 \alias{get_posterior_mean}
 \alias{get_posterior_mean,stanfit-method}
+\alias{get_elapsed_time}
+\alias{get_elapsed_time,stanfit-method}
 \alias{get_inits,stanfit-method}
 \alias{get_logposterior} 
 \alias{get_logposterior,stanfit,logical-method}
@@ -137,6 +139,10 @@
     \item{\code{get_posterior_mean}}{\code{signature(object = "stanfit")}:
       get the posterior mean for parameters of interest (using \code{pars}
       to specify) among \emph{all} parameters.} 
+    \item{\code{get_elapsed_time}}{\code{signature(object = "stanfit")}:
+      get the warmup time and sample time spent to draw the samples.
+      A matrix of two columns is returned: each row has the time information
+      for one chain.}
     \item{\code{get_stancode}}{\code{signature(object = "stanfit")}:
       get the Stan code for the fitted model.}
     \item{\code{get_cppo_mode}}{\code{signature(object = "stanfit")}:

--- a/rstan/tests/unitTests/runit.test.misc.R
+++ b/rstan/tests/unitTests/runit.test.misc.R
@@ -7,3 +7,16 @@ test_mklist_fun <- function() {
   checkEquals(fun1("a"), 3, checkNames = FALSE)
   checkEquals(fun1("c"), 4, checkNames = FALSE)
 }
+
+test_get_time_from_csv <- function() {
+  tlines <- character(2)
+  tlines[1] <- "aa"
+  tlines[2] <- "aa"
+  checkTrue(all(is.na(rstan:::get_time_from_csv(""))))
+  checkTrue(all(is.na(rstan:::get_time_from_csv(tlines))))
+  tlines[1] <- "# Elapsed Time: 0.005308 seconds (Warm-up)"
+  tlines[2] <- "#               0.003964 seconds (Sampling)"
+  t <- rstan:::get_time_from_csv(tlines)
+  checkEquals(t, c(0.005308, 0.003964), checkNames = FALSE)
+  checkEquals(names(t), c("warmup", "sample"))
+}

--- a/rstan/tests/unitTests/runit.test.read_stan_csv.R
+++ b/rstan/tests/unitTests/runit.test.read_stan_csv.R
@@ -4,6 +4,11 @@ test_read_stan_csv <- function() {
                              full.names = TRUE))
   checkEquals(dim(as.array(exfit)), c(100, 4, 10))
   checkEquals(exfit@model_pars, c("mu", "sigma", "z", "alpha", "lp__"), checkNames = FALSE)
+  t <- matrix(c(0.005308, 0.003964, 0.004776, 0.003744, 0.010337, 0.002867, 0.004711, 0.004117),
+              byrow = TRUE, ncol = 2)
+  colnames(t) <- c("warmup", "sample")
+  rownames(t) <- paste0("chain:", 1:nrow(t))
+  checkEquals(get_elapsed_time(exfit), t)
 }
 
 test_read_stan_csv_incomplete_csv_0_samples <- function() {
@@ -11,6 +16,7 @@ test_read_stan_csv_incomplete_csv_0_samples <- function() {
                              pattern='rstan_doc_ex_incomplete_1.csv',
                              full.names = TRUE))
   checkEquals(exfit@model_pars, c("mu", "sigma", "z", "alpha", "lp__"), checkNames = FALSE)
+  checkTrue(is.null(get_elapsed_time(exfit)))
 }
 
 test_read_stan_csv_incomplete_csv_few_samples <- function() {

--- a/rstan/tests/unitTests/runit.test.stan_fun.R
+++ b/rstan/tests/unitTests/runit.test.stan_fun.R
@@ -20,7 +20,7 @@ test_stan_fun_parallel <- function() {
   fit3 <- sampling(fit@stanmodel, data = list(N = 2), chains = 2,
                    check_data = FALSE,  iter = 40,
                    cores = 2, open_progress = FALSE)
-  checkTrue(fit3@mode == 0)
+  checkTrue(fit3@mode != 0)
 }
 
 test_stan_fun_args <- function() {

--- a/rstan/tests/unitTests/runit.test.stan_fun.R
+++ b/rstan/tests/unitTests/runit.test.stan_fun.R
@@ -1,4 +1,21 @@
 # test some functionality of function stan()
+
+test_stan_fun_parallel <- function() {
+  code <- 'data { int N; } parameters { real y[N]; }  model {y ~ normal(0,1); }';
+  N <- 3
+  fit <- stan(model_code = code,
+              data = "N",
+              chains = 0,
+              cores = 2,
+              show_progress = FALSE)
+  checkTrue(fit@mode != 0)
+
+  fit2 <- stan(fit = fit, data = 'N', cores = 2,
+               chains = 4, show_progress = FALSE)
+  checkTrue(fit@mode == 0)
+  checkEquals(fit@chains, 4L)
+}
+
 test_stan_fun_args <- function() {
   csv_fname <- 'tsfa.csv'
   csv_fname2 <- 'tsfa2.csv'

--- a/rstan/tests/unitTests/runit.test.stan_fun.R
+++ b/rstan/tests/unitTests/runit.test.stan_fun.R
@@ -7,13 +7,13 @@ test_stan_fun_parallel <- function() {
               data = "N",
               chains = 0,
               cores = 2,
-              show_progress = FALSE)
+              open_progress = FALSE)
   checkTrue(fit@mode != 0)
 
   fit2 <- stan(fit = fit, data = 'N', cores = 2,
-               chains = 4, show_progress = FALSE)
-  checkTrue(fit@mode == 0)
-  checkEquals(fit@chains, 4L)
+               chains = 4, open_progress = FALSE)
+  checkTrue(fit2@mode == 0)
+  checkEquals(fit2@sim$chains, 4L)
 }
 
 test_stan_fun_args <- function() {

--- a/rstan/tests/unitTests/runit.test.stan_fun.R
+++ b/rstan/tests/unitTests/runit.test.stan_fun.R
@@ -1,7 +1,7 @@
 # test some functionality of function stan()
 
 test_stan_fun_parallel <- function() {
-  code <- 'data { int N; } parameters { real y[N]; }  model {y ~ normal(0,1); }';
+  code <- 'data { int N; } parameters { real y[N]; }  model {y ~ normal(0,1); }'
   N <- 3
   fit <- stan(model_code = code,
               data = "N",
@@ -10,10 +10,17 @@ test_stan_fun_parallel <- function() {
               open_progress = FALSE)
   checkTrue(fit@mode != 0)
 
-  fit2 <- stan(fit = fit, data = 'N', cores = 2,
+  fit2 <- stan(fit = fit, data = "N", cores = 2,
                chains = 4, open_progress = FALSE)
   checkTrue(fit2@mode == 0)
   checkEquals(fit2@sim$chains, 4L)
+
+  # this should fail because check_data is false
+  # so that integer N cannot be found.
+  fit3 <- sampling(fit@stanmodel, data = list(N = 2), chains = 2,
+                   check_data = FALSE,  iter = 40,
+                   cores = 2, open_progress = FALSE)
+  checkTrue(fit3@mode == 0)
 }
 
 test_stan_fun_args <- function() {

--- a/rstan/tests/unitTests/runit.test.stanfit_get.R
+++ b/rstan/tests/unitTests/runit.test.stanfit_get.R
@@ -3,4 +3,7 @@ test_get_elapsed_time <- function() {
   nchains = 5L
   fit <- stan(model_code = code, chains = nchains, iter = 30)
   checkEquals(dim(get_elapsed_time(fit)), c(nchains, 2L))
+  nchains = 1L
+  fit2 <- stan(fit = fit, chains = nchains, iter = 30)
+  checkEquals(dim(get_elapsed_time(fit2)), c(nchains, 2L))
 }

--- a/rstan/tests/unitTests/runit.test.stanfit_get.R
+++ b/rstan/tests/unitTests/runit.test.stanfit_get.R
@@ -1,0 +1,6 @@
+test_get_elapsed_time <- function() {
+  code <- 'parameters { real y; } model {y ~ normal(0,1); }'
+  nchains = 5L
+  fit <- stan(model_code = code, chains = nchains, iter = 30)
+  checkEquals(dim(get_elapsed_time(fit)), c(nchains, 2L))
+}


### PR DESCRIPTION
This returns the wall time (warmup and sample) spent by the sampler to the stanfit object (part of issue #128)

Additionally, this address issue #146 and fixes new issues 
- chains = 0 does not work when cores is specifed
- returns a stanfit object (the first of the list) when the list from parallel chains cannot be consolidated into one 
- fix the case when the data argument are just object names for parallel running (previously, only the names are sent to other processes when data argument are just a vector of names so the data would not be found)
