### PR TITLE
R CMD config CXX: call the same R as in session

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -96,7 +96,8 @@ stan_model <- function(file,
     on.exit(rstan_options(eigen_lib = old.eigen_lib), add = TRUE) 
   }
 
-  check <- system2("R", args = "CMD config CXX", 
+  check <- system2(file.path(R.home(component = "bin"), "R"),
+                   args = "CMD config CXX", 
                    stdout = TRUE, stderr = FALSE)
   if(identical(check, "")) {
     WIKI <- "https://github.com/stan-dev/rstan/wiki/RStan-Getting-Started"


### PR DESCRIPTION
Call $RHOME/bin/R, don't assume that the R we need is located within the default $PATHs, there could be different R or no R at all.
