### PR TITLE
RStan was leaking connections

### DIFF
--- a/rstan/rstan/R/cxxfunplus.R
+++ b/rstan/rstan/R/cxxfunplus.R
@@ -76,7 +76,7 @@ cxxfun_from_dso_bin <- function(dso) {
 
   sig <- dso@sig 
   code <- dso@.CXXDSOMISC$cxxfun@code
-  tfile <- tempfile() 
+  tfile <- tempfile("cxxfunplus") 
   f <- basename(tfile) 
   libLFile <- paste(tfile, ".", filename_ext(dso@.CXXDSOMISC$dso_last_path), sep = '') 
   # write the raw vector containing the dso file to temporary file

--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -43,7 +43,7 @@ stan_model <- function(file,
     if (missing(model_name)) model_name <- NULL 
     
     if(missing(file)) {
-      tf <- tempfile()
+      tf <- tempfile("stan_model")
       writeLines(model_code, con = tf)
       file <- file.path(dirname(tf), paste0(tools::md5sum(tf), ".stan"))
       if(!file.exists(file)) file.rename(from = tf, to = file)
@@ -83,7 +83,7 @@ stan_model <- function(file,
        mtime.rda > rstan_load_time ||
        !is(obj <- readRDS(file.rda), "stanmodel") ||
        !is_sm_valid(obj) ||
-       !is.null(writeLines(obj@model_code, con = tf <- tempfile())) ||
+       !is.null(writeLines(obj@model_code, con = tf <- tempfile("obj_model_code"))) ||
        md5 != tools::md5sum(tf)) {
          # do nothing
     }
@@ -153,7 +153,7 @@ stan_model <- function(file,
                               model_cppcode = stanc_ret$cppcode))
   
   if(missing(file) || (file.access(dirname(file), mode = 2) != 0) || !isTRUE(auto_write)) {
-    tf <- tempfile()
+    tf <- tempfile("model_code")
     writeLines(model_code, con = tf)
     file <- file.path(tempdir(), paste0(tools::md5sum(tf), ".stan"))
     if(!file.exists(file)) file.rename(from = tf, to = file)

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -371,7 +371,7 @@ setMethod("sampling", "stanmodel",
                                   envir = environment()), list(...))
               .dotlist$chains <- 1L
               .dotlist$cores <- 1L
-              tfile <- tempfile()
+              tfile <- tempfile("sampling")
               sinkfile <- paste0(tfile, "_StanProgress.txt")
               cat("Click the Refresh button to see progress of the chains\n", file = sinkfile)
               if (open_progress && 
@@ -500,10 +500,12 @@ setMethod("sampling", "stanmodel",
               }
               if (is.character(show_messages)) 
                 messages <- normalizePath(show_messages, mustWork = FALSE)
-              else messages <- tempfile()
-              sink(file(messages, open = "wt"), type = "message")
+              else messages <- tempfile("messages")
+              con_messages <- file(messages, open = "wt")
+              sink(con_messages, type = "message")
               samples_i <- try(sampler$call_sampler(args_list[[i]]))
               sink(NULL, type = "message")
+              close(con_messages)
               report <- scan(file = messages, what = character(),
                              sep = "\n", quiet = TRUE)
               if (is(samples_i, "try-error") || is.null(samples_i)) {

--- a/rstan3/R/StanProgramMethods.R
+++ b/rstan3/R/StanProgramMethods.R
@@ -19,7 +19,7 @@ StanProgram$methods(initialize = function(file = file.choose(), code, auto_write
                                           rstan_options("auto_write"), ...) {
   "Initializes an object of the StanProgram class"
   if (!missing(code)) {
-    tf <- tempfile()
+    tf <- tempfile("stanprogram")
     writeLines(code, con = tf)
     md5 <- tools::md5sum(tf)
     file <- file.path(tempdir(), paste0(md5, ".stan"))
@@ -48,7 +48,7 @@ StanProgram$methods(show = function() {
 StanProgram$methods(expose = function() {
   "Brings user-defined Stan functions into the R environment
   Useful for unit-testing, posterior simulation, information criteria, etc."
-  rstan::testify(writeLines(.self$stan_code, con = tempfile()))
+  rstan::testify(writeLines(.self$stan_code, con = tempfile("testify")))
 })
 
 StanProgram$methods(instantiate = function(data = list()) {


### PR DESCRIPTION
I changed all tempfile calls to use descriptive prefixes, and found that the file argument to "sink" resulted in a connection that had not been closed.
