### PR TITLE
Use pointer objects for .Call()-ing C functions

### DIFF
--- a/rstan/rstan/R/chains.R
+++ b/rstan/rstan/R/chains.R
@@ -18,7 +18,7 @@
 rstan_ess <- function(sim, n) {
   # Args:
   #   n: Chain index starting from 1.
-  ess <- .Call("effective_sample_size", sim, n - 1)
+  ess <- .Call(effective_sample_size, sim, n - 1)
   ess
 } 
 
@@ -26,21 +26,21 @@ rstan_splitrhat <- function(sim, n) {
   # Args:
   #   n: Chain index starting from 1.
   if (sim$n_save[1] - sim$warmup2[1] < 2) return(NaN)
-  rhat <- .Call("split_potential_scale_reduction", sim, n - 1)
+  rhat <- .Call(split_potential_scale_reduction, sim, n - 1)
   rhat
 }
 
 rstan_splitrhat2_cpp <- function(sims) {
   # Args:
   #   sim: samples of several chains _without_ warmup
-  rhat <- .Call("split_potential_scale_reduction2", sims)
+  rhat <- .Call(split_potential_scale_reduction2, sims)
   rhat
 }
 
 rstan_ess2_cpp <- function(sims) {
   # Args:
   #   sim: samples of several chains _without_ warmup
-  ess <- .Call("effective_sample_size2", sims)
+  ess <- .Call(effective_sample_size2, sims)
   ess
 } 
 
@@ -52,6 +52,6 @@ rstan_seq_perm <- function(n, chains, seed, chain_id = 1) {
   #   chain_id: the chain id, for which the returned permuation is applied 
   # 
   conf <- list(n = n, chains = chains, seed = seed, chain_id = chain_id) 
-  perm <- .Call("seq_permutation", conf)
+  perm <- .Call(seq_permutation, conf)
   perm + 1L # start from 1 
 } 

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1372,7 +1372,7 @@ makeconf_path <- function() {
 } 
 
 is_null_ptr <- function(ns) {
-  .Call("is_Null_NS", ns)
+  .Call(is_Null_NS, ns)
 }
 
 is_null_cxxfun <- function(cx) {
@@ -1380,7 +1380,7 @@ is_null_cxxfun <- function(cx) {
   # contains null pointer 
   add <- body(cx@.Data)[[2]]
   # add is of class NativeSymbol
-  .Call("is_Null_NS", add)
+  .Call(is_Null_NS, add)
 }
 
 obj_size_str <- function(x) {
@@ -1402,7 +1402,7 @@ read_comments_old <- function(file, n) {
   # Args:
   #   file: the filename 
   #   n: max number of line; -1 means all 
-  .Call("CPP_read_comments", file, n)
+  .Call(CPP_read_comments, file, n)
 } 
 
 read_comments <- function(f, n = -1) {

--- a/rstan/rstan/R/monitor.R
+++ b/rstan/rstan/R/monitor.R
@@ -16,7 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # stan_prob_autocovariance <- function(v) { 
-#   .Call("stan_prob_autocovariance", v)
+#   .Call(stan_prob_autocovariance, v)
 # }
 
 ess_rfun <- function(sims) {

--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -32,7 +32,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model",
   
   # model_name in C++, to avoid names that would be problematic in C++. 
   model_cppname <- legitimate_model_name(model_name, obfuscate_name = obfuscate_model_name) 
-  r <- .Call("CPP_stanc280", model_code, model_cppname)
+  r <- .Call(CPP_stanc280, model_code, model_cppname)
   # from the cpp code of stanc,
   # returned is a named list with element 'status', 'model_cppname', and 'cppcode' 
   r$model_name <- model_name  
@@ -59,7 +59,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model",
 
 
 stan_version <- function() {
-  .Call('CPP_stan_version')
+  .Call(CPP_stan_version)
 }
 
 rstudio_stanc <- function(filename) {


### PR DESCRIPTION
Hi,

I tried to use the dev version of rstan and got these errors:

``` r
  "CPP_stanc280" not available for .Call() for package "rstan"
```

I'm not sure what was the cause. Everything seemed fine according to `getDLLRegisteredRoutines("rstan")`.

In any case, the problem goes away by supplying pointer objects to `.Call()` instead of the function names. This should also be a tiny bit faster. Note that the base package "stats" (that you took as a reference in `init.cpp`) uses this method to call its C routines.

See `rstan:::CPP_stan_version` to see an example of those pointer objects. They are created automatically because of that line in NAMESPACE: `useDynLib(rstan, .registration = TRUE)`
