### PR TITLE
Fixed searching for g++ on Windows

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1625,9 +1625,16 @@ throw_sampler_warnings <- function(object) {
 }
 
 get_CXX <- function(CXX11 = FALSE) {
-  system2(file.path(R.home(component = "bin"), "R"), 
-          args = paste("CMD config", ifelse(CXX11, "CXX11", "CXX")), 
-          stdout = TRUE, stderr = FALSE)
+  # system2(file.path(R.home(component = "bin"), "R"), 
+  #         args = paste("CMD config", ifelse(CXX11, "CXX1X", "CXX")), 
+  #         stdout = TRUE, stderr = FALSE)
+    
+    ls_path <- Sys.which("ls")
+    if (ls_path == "") 
+        return(NULL)
+    
+    install_path <- dirname(dirname(ls_path))
+    file.path(install_path, 'mingw_64', 'bin', 'g++')
 }
 
 is.sparc <- function() {


### PR DESCRIPTION
#### Summary:

If RTools is installed in a non-standard location using `R CMD config…
… "CXX"` returns the wrong location. This checks for the install location of `ls` which gives the root directory of the RTools installation. This then has `mingw_64/bin/g++` appended to it.

Also, the code (which is now commented out) checked for "CXX11" which is not an option with `R CMD config`.  It should have been "CXX1X" but it's moot now.
#### Intended Effect:

Finds rtools installation of g++
#### How to Verify:

Compile a model on Windows
#### Side Effects:
#### Documentation:
#### Reviewer Suggestions:
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Two lines of code (https://github.com/stan-dev/rstan/pull/312/commits/a6192daed41df1449b6c3d6c6831e3440b048df6#diff-b48ae07c233e40e6ba84617e23b758f0R1632) adapted from Hadley Wickham (https://github.com/hadley/devtools/blob/master/R/rtools.r#L143) and two lines added (https://github.com/stan-dev/rstan/pull/312/commits/a6192daed41df1449b6c3d6c6831e3440b048df6#diff-b48ae07c233e40e6ba84617e23b758f0R1636) by Jared P. Lander.  

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

… "CXX"`returns the wrong location.  This checks for the install location of`ls`which gives the root directory of the RTools installation.  This then has`mingw_64/bin/g++` appended to it.

Also, the code (which is now commented out) checked for "CXX11" which is not an option with `R CMD config`.  It should have been "CXX1X" but it's moot now.
