### PR TITLE
force model_name to not be named F

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -1,3 +1,4 @@
+s
 # This file is part of RStan
 # Copyright (C) 2012, 2013, 2014, 2015, 2016 Trustees of Columbia University
 #
@@ -36,9 +37,6 @@ stan_model <- function(file,
   #     by using returned results from stanc. 
   #   model_code: if file is not specified, we can used 
   #     a character to specify the model.   
-  model_re <- "(^[[:alpha:]]{2,}.*$)|(^[A-E,G-Z,a-z].*$)|(^F.+)"
-  if(!grepl(model_re, model_name))
-    stop("model name must match ", model_re)
   if (is.null(stanc_ret)) {
     model_name2 <- deparse(substitute(model_code))
     if (is.null(attr(model_code, "model_name2")))
@@ -58,7 +56,11 @@ stan_model <- function(file,
                        obfuscate_model_name = obfuscate_model_name)
     
     # find possibly identical stanmodels
-    S4_objects <- apropos(model_re, mode = "S4")
+    model_re <- "(^[[:alpha:]]{2,}.*$)|(^[A-E,G-S,U-Z,a-z].*$)|(^[F,T].+)"
+    if(!is.null(model_name))
+      if(!grepl(model_re, model_name))
+        stop("model name must match ", model_re)
+    S4_objects <- apropos(model_re, mode="S4", ignore.case=FALSE)
     if (length(S4_objects) > 0) {
       pf <- parent.frame()
       stanfits <- sapply(mget(S4_objects, envir = pf, inherits = TRUE), 

--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -36,7 +36,9 @@ stan_model <- function(file,
   #     by using returned results from stanc. 
   #   model_code: if file is not specified, we can used 
   #     a character to specify the model.   
-
+  model_re <- "(^[[:alpha:]]{2,}.*$)|(^[A-E,G-Z,a-z].*$)|(^F.+)"
+  if(!grepl(model_re, model_name))
+    stop("model name must match ", model_re)
   if (is.null(stanc_ret)) {
     model_name2 <- deparse(substitute(model_code))
     if (is.null(attr(model_code, "model_name2")))
@@ -56,7 +58,7 @@ stan_model <- function(file,
                        obfuscate_model_name = obfuscate_model_name)
     
     # find possibly identical stanmodels
-    S4_objects <- apropos("^[[:alpha:]]+.*$", mode = "S4")
+    S4_objects <- apropos(model_re, mode = "S4")
     if (length(S4_objects) > 0) {
       pf <- parent.frame()
       stanfits <- sapply(mget(S4_objects, envir = pf, inherits = TRUE), 


### PR DESCRIPTION
#### Summary: Make stan_model work during R CMD check
#### Intended Effect: Don't search for models named F (as not allowed by R)
#### How to Verify: include a call to stan_model in any documentation and run R CMD check
#### Side Effects: Breaks backwards compatibility with models named F
#### Documentation:
#### Reviewer Suggestions:
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

recently, R is prohibiting the use of F for FALSE during R CMD
check. While rstan doesn't use F anywhere it does use apropos to list
all variables in search for similar models. That listing includes the
built in F which R then intercepts as use of F and throws an
error. Seems more like an error in R but easy to fix here (although
obviously not backwards compatible with previous models named F.
