### PR TITLE
avoid R CMD check apropos using T/F

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -56,7 +56,11 @@ stan_model <- function(file,
                        obfuscate_model_name = obfuscate_model_name)
     
     # find possibly identical stanmodels
-    S4_objects <- apropos("^[[:alpha:]]+.*$", mode = "S4")
+    model_re <- "(^[[:alpha:]]{2,}.*$)|(^[A-E,G-S,U-Z,a-z].*$)|(^[F,T].+)"
+    if(!is.null(model_name))
+      if(!grepl(model_re, model_name))
+        stop("model name must match ", model_re)
+    S4_objects <- apropos(model_re, mode="S4", ignore.case=FALSE)
     if (length(S4_objects) > 0) {
       pf <- parent.frame()
       stanfits <- sapply(mget(S4_objects, envir = pf, inherits = TRUE), 


### PR DESCRIPTION
#### Summary: re-enable stan_model() in docs/vignettes
#### Intended Effect: R CMD check doesn't complain about use of T/F
#### How to Verify:Run R CMD check on a package that uses stan_model
#### Side Effects:Cant name model T or F anymore
#### Documentation:
#### Reviewer Suggestions:
#### Copyright and Licensing

@hredestig
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

recently, R is prohibiting the use of F/T for FALSE/TRUE during R CMD
check. While rstan doesn't use F/T anywhere it does use apropos to list
all variables in search for similar models. That listing includes the
built in F/T which R then intercepts as use of F and throws an
error. Seems more like an error in R but easy to fix here (although
obviously not backwards compatible with previous models named F or T.
