### PR TITLE
Use seq_along() instead of seq(along.with=)

### DIFF
--- a/rstan/rstan/R/cxxfunplus.R
+++ b/rstan/rstan/R/cxxfunplus.R
@@ -48,7 +48,7 @@ cxxfun_from_dll <- function(sig, code, DLL, check_dll = TRUE) {
 
     ## create .Call function call that will be added to 'fn'
     body <- quote(CALL_PLACEHOLDER(EXTERNALNAME, ARG))[c(1:2, rep(3, length(sig[[i]])))]
-    for (j in seq(along.with = sig[[i]])) body[[j + 2]] <- as.name(names(sig[[i]])[j])
+    for (j in seq_along(sig[[i]])) body[[j + 2]] <- as.name(names(sig[[i]])[j])
 
     body[[1L]] <- .Call
     body[[2L]] <- getNativeSymbolInfo(names(sig)[[i]], DLL)$address
@@ -102,7 +102,7 @@ cxxfun_from_dso_bin <- function(dso) {
 
     ## create .Call function call that will be added to 'fn'
     body <- quote(CALL_PLACEHOLDER(EXTERNALNAME, ARG))[c(1:2, rep(3, length(sig[[i]])))]
-    for (j in seq(along.with = sig[[i]])) body[[j + 2]] <- as.name(names(sig[[i]])[j])
+    for (j in seq_along(sig[[i]])) body[[j + 2]] <- as.name(names(sig[[i]])[j])
 
     body[[1L]] <- .Call
     body[[2L]] <- getNativeSymbolInfo(names(sig)[[i]], DLL)$address


### PR DESCRIPTION
#### Summary:

Undo the second commit of #317 and revert to the first one.
#### Intended Effect:

`seq_along()` is faster than `seq(along.with=)`.
#### How to Verify:
#### Side Effects:
#### Documentation:
#### Reviewer Suggestions:

@aadler, @bgoodri 
#### Copyright and Licensing
- @heavywatal
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
