### PR TITLE
read_stan_csv with readr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - tlmgr install ifnextok
 
 before_script: 
-  - Rscript -e "install.packages(c('inline', 'Rcpp', 'coda', 'BH', 'RcppEigen', 'RInside', 'RUnit', 'ggplot2', 'gridExtra', 'knitr', 'rmarkdown'), repos='http://cran.rstudio.com')"
+  - Rscript -e "install.packages(c('inline', 'Rcpp', 'coda', 'BH', 'RcppEigen', 'RInside', 'RUnit', 'ggplot2', 'gridExtra', 'knitr', 'rmarkdown', "readr"), repos='http://cran.rstudio.com')"
   - git config -f .gitmodules submodule.stan.branch ${STAN_BRANCH} 
   - git config -f .gitmodules submodule.StanHeaders/inst/include/mathlib.branch ${STAN_MATH_BRANCH}
   - git submodule update --remote

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - tlmgr install ifnextok
 
 before_script: 
-  - Rscript -e "install.packages(c('inline', 'Rcpp', 'coda', 'BH', 'RcppEigen', 'RInside', 'RUnit', 'ggplot2', 'gridExtra', 'knitr', 'rmarkdown', "readr"), repos='http://cran.rstudio.com')"
+  - Rscript -e "install.packages(c('inline', 'Rcpp', 'coda', 'BH', 'RcppEigen', 'RInside', 'RUnit', 'ggplot2', 'gridExtra', 'knitr', 'rmarkdown', 'readr'), repos='http://cran.rstudio.com')"
   - git config -f .gitmodules submodule.stan.branch ${STAN_BRANCH} 
   - git config -f .gitmodules submodule.StanHeaders/inst/include/mathlib.branch ${STAN_MATH_BRANCH}
   - git submodule update --remote

--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -28,7 +28,7 @@ Description: User-facing R functions are provided to parse, compile, test,
     to derive the partial derivatives.
 License: GPL (>=3)
 NeedsCompilation: yes
-Imports: methods, stats4, inline, gridExtra (>= 2.0.0), Rcpp (>= 0.12.0)
+Imports: methods, stats4, inline, gridExtra (>= 2.0.0), Rcpp (>= 0.12.0), readr (>= 1.0.0)
 Depends: R (>= 3.0.2), ggplot2 (>= 2.0.0), StanHeaders (>= 2.11.0)
 LinkingTo: Rcpp (>= 0.12.0), RcppEigen, BH (>= 1.60), StanHeaders (>= 2.11.0)
 Suggests: RUnit, RcppEigen, BH (>= 1.60), parallel, KernSmooth, RCurl, loo (>= 0.1.6), shinystan (>= 2.2.1), rstudioapi, Matrix, knitr

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -138,12 +138,14 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     header <- read_csv_header(csvfiles[i])
     lineno <- attr(header, 'lineno')
     vnames <- strsplit(header, ",")[[1]]
-    m <- matrix(scan(csvfiles[i], skip = lineno, comment.char = '#', sep = ',', quiet = TRUE),
-                ncol = length(vnames), byrow = TRUE)
+    m <- as.matrix(
+      readr::read_csv(csvfiles[i], 
+                      comment = "#", 
+                      col_types = readr::cols(.default = readr::col_double())))
     ss_lst[[i]] <- as.data.frame(m)
     colnames(ss_lst[[i]]) <- vnames 
   } 
-
+  
   ## read.csv is slow for large files 
   ##ss_lst <- lapply(csvfiles, function(csv) read.csv(csv, header = TRUE, skip = 10, comment.char = '#'))
   # use the first CSV file name as model name

--- a/rstan/rstan/man/stan_csv.Rd
+++ b/rstan/rstan/man/stan_csv.Rd
@@ -4,6 +4,8 @@
 \description{Create a \code{stanfit} object from the saved CSV files that are
   created by Stan or RStan and that include the samples drawn from the
   distribution of interest to facilitate analysis of samples using RStan.  
+  These csv files may be plain text or---if the file name ends in 
+  .gz, .bz2, .xz, or .zip---they can also be compressed files.
 } 
 
 \usage{
@@ -34,6 +36,7 @@ read_stan_csv(csvfiles, col_major = TRUE)
 
 \seealso{
   \code{\linkS4class{stanfit}} 
+  \code{\link[readr]{read_csv}}
 } 
 \examples{
 csvfiles <- dir(system.file('misc', package = 'rstan'),


### PR DESCRIPTION
#### Summary:

Use Hadley's `read_csv` to read in CSV files instead of `scan`.
#### Intended Effect:

Speed up CSV reading by nearly a factor of 2.  In some preliminary tests, it appeared that this step took about 50% of the time involved in running `read_stan_csv`, so the total change should be 25% faster for the whole function.

The speed improvements would be even larger if the csv files were compressed, as `read_csv` can read compressed files very quickly.
#### How to Verify:

The following line should verify that the model output has not changed for a given file (assuming that this branch is installed as `rstan_new` and the previous branch is installed as `rstan`).

`all.equal(rstan_new::read_stan_csv("csvfile")@sim$samples, rstan::read_stan_csv("csvfile")@sim$samples)`

I'm having trouble building rstan on my machine, so I apologize in advance if it doesn't run smoothly on the first submission. 
#### Side Effects:

None intended
#### Documentation:

Added a brief mention of how to read compressed files
#### Reviewer Suggestions:
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

David J. Harris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
