### PR TITLE
allow user to specify environment for exposed funs

### DIFF
--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-expose_stan_functions <- function(stanmodel) {
+expose_stan_functions <- function(stanmodel, env = globalenv()) {
   if(is(stanmodel, "stanfit")) {
     stanmodel <- get_stanmodel(stanmodel)
     stanmodel <- get_cppcode(stanmodel)
@@ -241,7 +241,7 @@ expose_stan_functions <- function(stanmodel) {
   # try to compile
   on.exit(message("Here is the C++ code that does not compile. Please report bug."))
   on.exit(print(lines), add = TRUE)
-  compiled <- Rcpp::sourceCpp(code = paste(lines, collapse = "\n"))
+  compiled <- Rcpp::sourceCpp(code = paste(lines, collapse = "\n"), env = env)
   on.exit(NULL)
   return(invisible(compiled$functions))
 }

--- a/rstan/rstan/man/expose_stan_functions.Rd
+++ b/rstan/rstan/man/expose_stan_functions.Rd
@@ -8,9 +8,9 @@ Expose user-defined Stan functions to \R for testing and simulation
   \code{functions} block at the top of a Stan program. The 
   \code{expose_stan_functions} utility function uses
   \code{\link[Rcpp]{sourceCpp}} to export those user-defined functions
-  to the user's workspace (\code{\link{.GlobalEnv}}) for 
-  testing inside \R or for doing posterior predictive simulations in \R rather 
-  than in the \code{generated quantities} block of a Stan program.
+  to the specified environment for testing inside \R or for doing posterior
+  predictive simulations in \R rather than in the \code{generated 
+  quantities} block of a Stan program.
 }
 \usage{
   expose_stan_functions(stanmodel)
@@ -23,6 +23,9 @@ Expose user-defined Stan functions to \R for testing and simulation
     program (\code{.stan} file). In any of these cases, the underlying Stan 
     program should contain a non-empty \code{functions} block.
   }
+ \item{environment}{
+   an \code{\link[base]{environment}}. By default, the global environment
+   is used.
 }
 
 \details{

--- a/rstan/rstan/man/expose_stan_functions.Rd
+++ b/rstan/rstan/man/expose_stan_functions.Rd
@@ -23,7 +23,7 @@ Expose user-defined Stan functions to \R for testing and simulation
     program (\code{.stan} file). In any of these cases, the underlying Stan 
     program should contain a non-empty \code{functions} block.
   }
- \item{environment}{
+ \item{env}{
    an \code{\link[base]{environment}}. By default, the global environment
    is used.
 }


### PR DESCRIPTION
#### Summary:

In `expose_stan_functions`, allow the user to pass an environment object to `Rcpp::sourceCpp`
#### Intended Effect:

Allow for the addition of Stan-based functions to other environments and namespaces
#### How to Verify:

Given a suitable `stanmodel` object, the following code should save the functions to the `my_env` environment and then list the functions that were saved there.

```
my_env = new.env()
expose_stan_functions(stanmodel, env = my_env)
print(ls(my_env))
```
#### Side Effects:

None expected: the global environment will still be used by default.
#### Documentation:

Updated in the .Rd file for `expose_stan_functions`
#### Reviewer Suggestions:
#### Copyright and Licensing

copyright holder: David J. Harris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
