### PR TITLE
clarify adjust_transform in docs

### DIFF
--- a/rstan/rstan/man/stanfit-method-logprob.Rd
+++ b/rstan/rstan/man/stanfit-method-logprob.Rd
@@ -11,21 +11,21 @@
 \alias{get_num_upars}
 \alias{get_num_upars,stanfit-method}
 
-\title{Model's \code{log_prob} and \code{grad_log_prob} functions} 
+\title{Model's \code{log_prob} and \code{grad_log_prob} functions}
 
 \description{
-  Using model's \code{log_prob} and \code{grad_log_prob} functions  
-  on the unconstrained space of model parameters. Sometimes we   
-  need to convert the values of parameters from their support defined 
-  in the parameters block (which might be constrained, and for simplicity, 
-  we call it the constrained space) to the unconstrained space and vice versa. 
-  The \code{constrain_pars} and \code{unconstrain_pars} functions are used 
+  Using model's \code{log_prob} and \code{grad_log_prob} functions
+  on the unconstrained space of model parameters. Sometimes we
+  need to convert the values of parameters from their support defined
+  in the parameters block (which might be constrained, and for simplicity,
+  we call it the constrained space) to the unconstrained space and vice versa.
+  The \code{constrain_pars} and \code{unconstrain_pars} functions are used
   for this purpose.
-} 
+}
 \usage{
-  %% log_prob(object, upars, adjust_transform = TRUE, gradient = FALSE) 
+  %% log_prob(object, upars, adjust_transform = TRUE, gradient = FALSE)
   \S4method{log_prob}{stanfit}(object, upars, adjust_transform = TRUE, gradient = FALSE)
-  %% grad_log_prob(object, upars, adjust_transform = TRUE) 
+  %% grad_log_prob(object, upars, adjust_transform = TRUE)
   \S4method{grad_log_prob}{stanfit}(object, upars, adjust_transform = TRUE)
   %% get_num_upars(object)
   \S4method{get_num_upars}{stanfit}(object)
@@ -33,20 +33,20 @@
   \S4method{constrain_pars}{stanfit}(object, upars)
   %% unconstrain_pars(object, pars)
   \S4method{unconstrain_pars}{stanfit}(object, pars)
-} 
+}
 
 \section{Methods}{
   \describe{
-    \item{log_prob}{\code{signature(object = "stanfit")}}{Compute the log posterior 
-      (\code{lp__}) for the model represented by a \code{stanfit} object. 
+    \item{log_prob}{\code{signature(object = "stanfit")}}{Compute the log posterior
+      (\code{lp__}) for the model represented by a \code{stanfit} object.
     }
     \item{grad_log_prob}{\code{signature(object = "stanfit")}}{Compute the gradients
-      for \code{log_prob} as well as the log posterior. The latter is returned as 
-      an attribute. 
+      for \code{log_prob} as well as the log posterior. The latter is returned as
+      an attribute.
     }
     \item{get_num_upars}{\code{signature(object = "stanfit")}}{Get the number
       of unconstrained parameters.
-    } 
+    }
     \item{constrain_pars}{\code{signature(object = "stanfit")}}{Convert values
       of the parameter from unconstrained space (given as a vector) to their
       constrained space (returned as a named list).}
@@ -55,67 +55,68 @@
       to unconstrained space.
     }
   }
-} 
+}
 
 \arguments{
   \item{object}{An object of class \code{\linkS4class{stanfit}}.}
   \item{pars}{An list specifying the values for all parameters on the
-    constrained space.} 
-  \item{upars}{A numeric vector for specifying the values for all parameters 
-    on the unconstrained space.}  
+    constrained space.}
+  \item{upars}{A numeric vector for specifying the values for all parameters
+    on the unconstrained space.}
   \item{adjust_transform}{Logical to indicate whether to adjust
     the log density since Stan transforms parameters to unconstrained
-    space if it is in constrained space.} 
-  \item{gradient}{Logical to indicate whether gradients are also 
-    computed as well as the log density. 
-  } 
-} 
+    space if it is in constrained space. Set to \code{FALSE} to make the
+    function return the same values as Stan's \code{lp__} output.} 
+  \item{gradient}{Logical to indicate whether gradients are also
+    computed as well as the log density.
+  }
+}
 
 \details{
   Stan requires that parameters be defined along with their support.
-  For example, for a variance parameter, we must define it 
+  For example, for a variance parameter, we must define it
   on the positive real line. But inside Stan's samplers, all parameters
   defined on the constrained space are transformed to unconstrained
   space, so the log density function need be adjusted (i.e., adding
   the log of the absolute value of the Jacobian determinant).
-  With the transformation, Stan's samplers work on the unconstrained space and 
+  With the transformation, Stan's samplers work on the unconstrained space and
   once a new iteration is drawn, Stan transforms the parameters
   back to their supports. All the transformation are done by Stan without
   interference from the users.  However, when using the log density function
   for a model exposed to R, we need to be careful.
-  For example, if we are interested in finding the mode of parameters 
-  on the constrained space, we then do not need the adjustment. 
-  For this reason, the \code{log_prob} and \code{grad_log_prob} functions 
+  For example, if we are interested in finding the mode of parameters
+  on the constrained space, we then do not need the adjustment.
+  For this reason, the \code{log_prob} and \code{grad_log_prob} functions
   accept an \code{adjust_transform} argument.
-} 
+}
 
 \value{
-  \code{log_prob} returns a value (up to an additive constant) the log posterior. 
+  \code{log_prob} returns a value (up to an additive constant) the log posterior.
   If \code{gradient} is \code{TRUE},  the gradients are also returned as an
   attribute with name \code{gradient}.
 
   \code{grad_log_prob} returns a vector of the gradients.  Additionally, the vector
   has an attribute named \code{log_prob} being the value the same as \code{log_prob}
-  is called for the input parameters. 
+  is called for the input parameters.
 
-  \code{get_num_upars} returns the number of parameters on the unconstrained space. 
+  \code{get_num_upars} returns the number of parameters on the unconstrained space.
 
-  \code{constrain_pars} returns a list and \code{unconstrain_pars} returns a vector. 
+  \code{constrain_pars} returns a list and \code{unconstrain_pars} returns a vector.
 }
 
 \references{
-  The Stan Development Team 
-  \emph{Stan Modeling Language User's Guide and Reference Manual}. 
-  \url{http://mc-stan.org}. 
+  The Stan Development Team
+  \emph{Stan Modeling Language User's Guide and Reference Manual}.
+  \url{http://mc-stan.org}.
 }
 
 \seealso{
-  \code{\linkS4class{stanfit}} 
-} 
+  \code{\linkS4class{stanfit}}
+}
 
 \examples{\dontrun{
 # see the examples in the help for stanfit as well
-# do a simple optimization problem 
+# do a simple optimization problem
 opcode <- "
 parameters {
   real y;
@@ -130,13 +131,13 @@ or <- optim(1, tfun, tgrfun, method = 'BFGS')
 print(or)
 
 # return the gradient as an attribute
-tfun2 <- function(y) { 
-  g <- grad_log_prob(opfit, y) 
+tfun2 <- function(y) {
+  g <- grad_log_prob(opfit, y)
   lp <- attr(g, "log_prob")
   attr(lp, "gradient") <- g
   lp
-} 
+}
 
 or2 <- nlm(tfun2, 10)
-or2 
-}} 
+or2
+}}


### PR DESCRIPTION
#### Summary:

Clarify the effect of `adjust_transform` in the `log_prob` family of functions.
#### Intended Effect:

Prevent other users from being as confused by this as I was when rstan's `log_prob` doesn't match Stan's `lp__`.

In future versions, it may be desirable to change the name of this option and/or the default behavior so that the two measures of a model's log probability match unless the user asks for something different.
#### How to Verify:

N/A
#### Side Effects:

N/A
#### Documentation:

Yes
#### Reviewer Suggestions:

Any
#### Copyright and Licensing

David J. Harris

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
