### PR TITLE
Changed keep.source argument in source (called by read_rdump) to mass…

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -653,7 +653,7 @@ plot_rhat_legend <- function(x, y, cex = 1) {
 } 
   
 
-read_rdump <- function(f) {
+read_rdump <- function(f, keep.source = FALSE, ...) {
   # Read data defined in an R dump file to an R list
   # 
   # Args:
@@ -665,7 +665,7 @@ read_rdump <- function(f) {
   if (missing(f)) 
     stop("no file specified.")
   e <- new.env()
-  source(file = f, local = e)
+  source(file = f, local = e, keep.source = keep.source, ...)
   as.list(e)
 } 
 


### PR DESCRIPTION
#### Summary: Altered read_rdump() to pass in keep.source = FALSE to source(). 

#### Intended Effect: Massive speed improvement in read time.

#### How to Verify:

```
test <- 1:1e5
 stan_rdump("test", file = "test.rdump")
# With new default keep.source = FALSE
system.time({a = read_rdump("test.rdump")})
   user  system elapsed 
  0.107   0.000   0.107 
# With old default keep.source = TRUE
system.time({b = read_rdump("test.rdump", keep.source = TRUE)})
   user  system elapsed 
 21.920   0.004  21.956 
identical(a, b)
[1] TRUE
```

#### Side Effects: None

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Duncan Temple Lang and Matt Espe

Patch submitted with no restrictions on use. 

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

