### PR TITLE
Use file extension .rds for compiled stanmodels, instead of .rda.

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -79,15 +79,15 @@ stan_model <- function(file,
     }
     
     mtime <- file.info(file)$mtime
-    file.rda <- gsub("stan$", "rda", file)
+    file.rds <- gsub("stan$", "rds", file)
     md5 <- tools::md5sum(file)
-    if (!file.exists(file.rda)) {
-      file.rda <- file.path(tempdir(), paste0(md5, ".rda"))
+    if (!file.exists(file.rds)) {
+      file.rds <- file.path(tempdir(), paste0(md5, ".rds"))
     }
-    if(!file.exists(file.rda) ||
-       (mtime.rda <- file.info(file.rda)$mtime) < 
+    if(!file.exists(file.rds) ||
+       (mtime.rds <- file.info(file.rds)$mtime) < 
        as.POSIXct(packageDescription("rstan")$Date) ||
-       !is(obj <- readRDS(file.rda), "stanmodel") ||
+       !is(obj <- readRDS(file.rds), "stanmodel") ||
        !is_sm_valid(obj) ||
        !is.null(writeLines(obj@model_code, con = tf <- tempfile())) ||
        (md5 != tools::md5sum(tf) && is.null(
@@ -173,9 +173,9 @@ stan_model <- function(file,
     file <- file.path(tempdir(), paste0(tools::md5sum(tf), ".stan"))
     if(!file.exists(file)) file.rename(from = tf, to = file)
     else file.remove(tf)
-    saveRDS(obj, file = gsub("stan$", "rda", file))
+    saveRDS(obj, file = gsub("stan$", "rds", file))
   }
-  else if(isTRUE(auto_write)) saveRDS(obj, file = gsub("stan$", "rda", file))
+  else if(isTRUE(auto_write)) saveRDS(obj, file = gsub("stan$", "rds", file))
   
   invisible(obj) 
   ## We keep a reference to *dso* above to avoid dso to be 

--- a/rstan/rstan/man/stan_model.Rd
+++ b/rstan/rstan/man/stan_model.Rd
@@ -60,7 +60,7 @@
     \code{rstan_options("auto_write" = TRUE)} in order to avoid unnecessary 
     recompilations. If \code{file} is supplied and its \code{\link{dirname}} 
     is writable, then the object will be written to that same directory, 
-    substituting a \code{.rda} extension for the \code{.stan} extension. 
+    substituting a \code{.rds} extension for the \code{.stan} extension. 
     Otherwise, the object will be written to the \code{\link{tempdir}}.}
   \item{obfuscate_model_name}{A logical scalar that is \code{TRUE} by default and
     passed to \code{\link{stanc}}.}

--- a/rstan3/R/StanProgramMethods.R
+++ b/rstan3/R/StanProgramMethods.R
@@ -35,8 +35,8 @@ StanProgram$methods(initialize = function(file = file.choose(), code, auto_write
   .self$cpp_code <<- scan(text = ret$cppcode, what = character(), 
                           sep = "\n", quiet = TRUE)
   .self$dso <<- rstan::stan_model(file, auto_write = FALSE, ...)@dso
-  if (auto_write) .self$save(file = sub("stan$", "rda", file))
-  else .self$save(file = file.path(tempdir(), paste0(md5, ".rda")))
+  if (auto_write) .self$save(file = sub("stan$", "rds", file))
+  else .self$save(file = file.path(tempdir(), paste0(md5, ".rds")))
   return(invisible(NULL))
 })
 


### PR DESCRIPTION
#### Summary:

As discussed in issue #361, `.rds` would be a more appropriate file extension for saving compiled `stanmodel`s than the current `.rda`. This is because they are saved with `saveRDS()`, for which the standard extension is `.rds` (whereas `.rda` and `.RData` are standard extensions for `save()`).

#### Intended Effect:

Use file extension `.rds` for compiled `stanmodel`s.

#### How to Verify:

Compiled `stanmodel` files saved with `stan_model()` have the new extension. From the manual page:

> If ‘file’ is supplied and its ‘dirname’ is writable, then the object will be written to that same directory, substituting a ‘.rds’ extension for the ‘.stan’ extension.  Otherwise, the object will be written to the ‘tempdir’.

#### Side Effects:

1. At the moment, existing `.rda` files are simply overwritten. Current users are aware of this behavior, but if the extension is suddenly changed to `.rds`, continuing to overwrite incurs some risk of overwriting other files (model fits, input data,…) users could have saved with this filename. I can append this PR with whatever approach is deemed suitable to deal with this situation. One option to mitigate the risk would be to check the class of the R object that is stored in the existing file, and only overwrite if it's a `stanmodel`. This could be done either:
   1. around [line 178](https://github.com/ilarischeinin/rstan/blob/9e3085ef0e44a004b44df11a4f8caab9f856c2f2/rstan/rstan/R/rstan.R#L178) where the (new) model file is saved. If another file was present, saving the model could be skipped ("file exists and is not a stanmodel, not overwriting").
   2. around [line 84](https://github.com/ilarischeinin/rstan/blob/9e3085ef0e44a004b44df11a4f8caab9f856c2f2/rstan/rstan/R/rstan.R#L84) where the (old) model file is read. If another file was present, execution could be stopped here ("file exist and is not a stanmodel, stopping").

2. Old `.rda` files are simply ignored. An automatic cleanup could be implemented, but as that could create problems analogous to the overwriting issue discussed above, I lean towards the safe option of leaving the cleanup to users.

#### Documentation:

The manual page for `stan_model()` has been updated accordingly.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ilari Scheinin

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

Closes #361