### PR TITLE
Feature/fork

### DIFF
--- a/rstan/rstan/R/rtools.R
+++ b/rstan/rstan/R/rtools.R
@@ -17,12 +17,15 @@
 
 find_rtools <- function(...) {
   if (.Platform$OS.type == "unix") return(TRUE)
+  CXX <- Sys.which("g++")
+  if (nchar(CXX) > 0) return(TRUE)
   CXX <- system2(file.path(Sys.getenv("R_HOME"), "bin",
                            Sys.getenv("R_ARCH_BIN"), "R"),
                  args = "CMD config CXX", stdout = TRUE)
-  if (nchar(CXX) > 0) return(TRUE)
-  CXX <- Sys.which("g++")
-  if (nchar(CXX) > 0) return(TRUE)
+  if (!is.null(attributes(CXX)$status)) {
+    # do nothing
+  }
+  else if (nchar(CXX) > 0) return(TRUE)
   message("No C++ compiler found, so the following will probably not work.")
   message("See https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows#toolchain")
   return(FALSE)

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -467,6 +467,7 @@ setMethod("sampling", "stanmodel",
                                   envir = environment()), list(...))
               .dotlist$chains <- 1L
               .dotlist$cores <- 1L
+              .dotlist$open_progress <- FALSE
               callFun <- function(i) {
                 .dotlist$chain_id <- i
                 if(is.list(.dotlist$init)) .dotlist$init <- .dotlist$init[i]
@@ -480,7 +481,8 @@ setMethod("sampling", "stanmodel",
                 out <- do.call(rstan::sampling, args = .dotlist)
                 return(out)
               }
-              if ( .Platform$OS.type == "unix" && isatty(stdout()) ) {
+              if ( .Platform$OS.type == "unix" && 
+                   (!interactive() || isatty(stdout())) ) {
                 nfits <- parallel::mclapply(1:chains, FUN = callFun, 
                                             mc.preschedule = FALSE, mc.cores = cores)
               }

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -467,41 +467,6 @@ setMethod("sampling", "stanmodel",
                                   envir = environment()), list(...))
               .dotlist$chains <- 1L
               .dotlist$cores <- 1L
-              tfile <- tempfile()
-              sinkfile <- paste0(tfile, "_StanProgress.txt")
-              cat("Click the Refresh button to see progress of the chains\n", file = sinkfile)
-              if (open_progress && 
-                  !identical(browser <- getOption("browser"), "false")) {
-                if (identical(Sys.getenv("RSTUDIO"), "1"))
-                  stop("you cannot specify 'open_progress = TRUE' when using RStudio")
-                sinkfile_html <- paste0(tfile, "_StanProgress.html")
-                create_progress_html_file(sinkfile_html, sinkfile)
-                utils::browseURL(paste0("file://", sinkfile_html))
-              }
-              else if (identical(Sys.getenv("RSTUDIO"), "1") && 
-                       .Platform$OS.type == "windows" && interactive()) {
-                if (!requireNamespace("rstudioapi"))
-                  stop("must install the rstudioapi package when using RStan in parallel via RStudio")
-                if (rstudioapi::isAvailable("0.98.423")) {
-                  v <- rstudioapi::getVersion()
-                  if (v > "0.99.100") rstudioapi::viewer(sinkfile, height = "maximize")
-                  else if (v >= "0.98.423") rstudioapi::viewer(sinkfile)
-                }
-                else sinkfile <- ""
-              }
-              else sinkfile <- ""
-              cl <- parallel::makeCluster(min(cores, chains), 
-                                          outfile = sinkfile, useXDR = FALSE)
-              on.exit(parallel::stopCluster(cl))
-              dependencies <- c("rstan", "Rcpp", "ggplot2")
-              .paths <- unique(c(.libPaths(), sapply(dependencies, FUN = function(d) {
-                dirname(system.file(package = d))
-              })))
-              .paths <- .paths[.paths != ""]
-              parallel::clusterExport(cl, varlist = ".paths", envir = environment())
-              parallel::clusterEvalQ(cl, expr = .libPaths(.paths))
-              parallel::clusterEvalQ(cl, expr = 
-                                    suppressPackageStartupMessages(require(rstan, quietly = TRUE)))
               callFun <- function(i) {
                 .dotlist$chain_id <- i
                 if(is.list(.dotlist$init)) .dotlist$init <- .dotlist$init[i]
@@ -515,10 +480,51 @@ setMethod("sampling", "stanmodel",
                 out <- do.call(rstan::sampling, args = .dotlist)
                 return(out)
               }
-              parallel::clusterExport(cl, varlist = ".dotlist", envir = environment())
-              data_e <- as.environment(data)
-              parallel::clusterExport(cl, varlist = names(data_e), envir = data_e)
-              nfits <- parallel::parLapplyLB(cl, X = 1:chains, fun = callFun)
+              if ( .Platform$OS.type == "unix" && isatty(stdout()) ) {
+                nfits <- parallel::mclapply(1:chains, FUN = callFun, 
+                                            mc.preschedule = FALSE, mc.cores = cores)
+              }
+              else {
+                tfile <- tempfile()
+                sinkfile <- paste0(tfile, "_StanProgress.txt")
+                cat("Click the Refresh button to see progress of the chains\n", file = sinkfile)
+                if (open_progress && 
+                    !identical(browser <- getOption("browser"), "false")) {
+                  if (identical(Sys.getenv("RSTUDIO"), "1"))
+                    stop("you cannot specify 'open_progress = TRUE' when using RStudio")
+                  sinkfile_html <- paste0(tfile, "_StanProgress.html")
+                  create_progress_html_file(sinkfile_html, sinkfile)
+                  utils::browseURL(paste0("file://", sinkfile_html))
+                }
+                else if (identical(Sys.getenv("RSTUDIO"), "1") && 
+                         .Platform$OS.type == "windows" && interactive()) {
+                  if (!requireNamespace("rstudioapi"))
+                    stop("must install the rstudioapi package when using RStan in parallel via RStudio")
+                  if (rstudioapi::isAvailable("0.98.423")) {
+                    v <- rstudioapi::getVersion()
+                    if (v > "0.99.100") rstudioapi::viewer(sinkfile, height = "maximize")
+                    else if (v >= "0.98.423") rstudioapi::viewer(sinkfile)
+                  }
+                  else sinkfile <- ""
+                }
+                else sinkfile <- ""
+                cl <- parallel::makeCluster(min(cores, chains), 
+                                            outfile = sinkfile, useXDR = FALSE)
+                on.exit(parallel::stopCluster(cl))
+                dependencies <- c("rstan", "Rcpp", "ggplot2")
+                .paths <- unique(c(.libPaths(), sapply(dependencies, FUN = function(d) {
+                  dirname(system.file(package = d))
+                })))
+                .paths <- .paths[.paths != ""]
+                parallel::clusterExport(cl, varlist = ".paths", envir = environment())
+                parallel::clusterEvalQ(cl, expr = .libPaths(.paths))
+                parallel::clusterEvalQ(cl, expr = 
+                                      suppressPackageStartupMessages(require(rstan, quietly = TRUE)))
+                parallel::clusterExport(cl, varlist = ".dotlist", envir = environment())
+                data_e <- as.environment(data)
+                parallel::clusterExport(cl, varlist = names(data_e), envir = data_e)
+                nfits <- parallel::parLapplyLB(cl, X = 1:chains, fun = callFun)
+              }
               valid <- sapply(nfits, is, class2 = "stanfit") &
                        sapply(nfits, FUN = function(x) x@mode == 0)
               if(all(valid)) {


### PR DESCRIPTION
#### Summary:

Use mclapply() when sampling() is called from a shell

#### Intended Effect:

Allow Stan to work better on Linux servers

#### How to Verify:

Call stan() with cores > 1 from a shell

#### Side Effects:

Less memory consumed

#### Documentation:

None

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
