### PR TITLE
Fix regexp in stan_model (fixes #385)

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -131,7 +131,7 @@ stan_model <- function(file,
   inc <- paste("#define STAN__SERVICES__COMMAND_HPP",
                # include, stanc_ret$cppcode,
                if(is.null(includes)) stanc_ret$cppcode else
-                 sub("(class.*: public prob_grad \\{)", 
+                 sub("(class[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*: public prob_grad \\{)",
                      paste(includes, "\\1"), stanc_ret$cppcode),
                "#include <rstan/rstaninc.hpp>\n", 
                get_Rcpp_module_def_code(model_cppname), 


### PR DESCRIPTION
#### Summary:

Changes how the placement of user supplied includes is determined, thus fixing issue #385.

#### Intended Effect:



regexp in call to `sub` in stan_model on line 134 of rstan.R will only matches the line defining a valid subclass of `prob_grad`, *i.e.* the model class. This prevents the insertion of the includes lines in the wrong place for cases when the `functions` block includes user defined random number generating functions (or rather functions ending with the _rng suffix).

#### How to Verify:

Failing example in #385 now generates a valid model object.

#### Side Effects:

None expected.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @torsti

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
