### PR TITLE
Introduce functions to check hmc diagnostics

### DIFF
--- a/rstan/rstan/NAMESPACE
+++ b/rstan/rstan/NAMESPACE
@@ -50,8 +50,12 @@ export(
   quietgg,
   extract_sparse_parts,
   rstan.package.skeleton,
-  cpp_object_initializer
+  cpp_object_initializer,
 # get_rstan.options
+  check_hmc_diagnostics,
+  check_divergences, 
+  check_treedepth, 
+  check_energy
 )
 
 exportClasses(

--- a/rstan/rstan/R/check_hmc_diagnostics.R
+++ b/rstan/rstan/R/check_hmc_diagnostics.R
@@ -1,0 +1,102 @@
+check_hmc_diagnostics <- function(object) {
+  cat("\nDivergences:\n")
+    check_divergences(object)
+  cat("\nTree depth:\n")
+    check_treedepth(object)
+  cat("\nEnergy:\n")
+    check_energy(object)
+}
+
+
+# Check transitions that ended with a divergence
+#
+# @param object stanfit object
+# @return nothing, just prints the number (and percentage) of iterations that
+#   ended with a divergence and, if any, suggests increasing adapt_delta.
+#
+check_divergences <- function(object) {
+  divergent <- sampler_param_vector(object, "divergent__")
+  n <- sum(divergent)
+  N <- length(divergent)
+  
+  if (n == 0) {
+    message(
+      sprintf("%s of %s iterations ended with a divergence.", n, N)
+    )
+  } else {
+    message(
+      sprintf("%s of %s iterations ended with a divergence (%s%%).",
+              n, N, 100 * n / N), 
+      "\nTry increasing 'adapt_delta' to remove the divergences."
+    )
+  }
+}
+
+# Check transitions that ended prematurely due to maximum tree depth limit
+#
+# @param object stanfit object
+# @return nothing, just prints the number (and percentage) of iterations that
+#   saturated the max treedepth and, if any, suggests increasing max_treedepth.
+#
+check_treedepth <- function(object) {
+  max_depth <- object@stan_args[[1]]$control$max_treedepth
+  if (is.null(max_depth)) {
+    max_depth <- 10
+  }
+  treedepths <- sampler_param_vector(object, "treedepth__")
+  n <- sum(treedepths == max_depth)
+  N <- length(treedepths)
+  
+  if (n == 0) {
+    message(
+      sprintf("%s of %s iterations saturated the maximum tree depth of %s.", 
+              n, N, max_depth)
+    )
+  } else {
+    message(
+      sprintf('%s of %s iterations saturated the maximum tree depth of %s (%s%%).',
+              n, N, max_depth, 100 * n / N), 
+      "\nTry increasing 'max_treedepth' to avoid saturation."
+    )
+  }
+}
+
+
+# Check the energy Bayesian fraction of missing information (E-BFMI)
+#
+# @param object stanfit object
+# @return nothing, just prints
+#
+check_energy <- function(object) {
+  energies_by_chain <- sampler_param_matrix(object, "energy__")
+  EBFMIs <- apply(energies_by_chain, 2, function(x) {
+    numer <- sum(diff(x) ^ 2) / length(x)
+    denom <- var(x)
+    numer / denom
+  })
+  bad_chains <- which(EBFMIs < 0.2)
+  if (!length(bad_chains)) {
+    message("E-BFMI indicated no pathological behavior.")
+  } else {
+    message(
+      "E-BFMI indicated possible pathological behavior:\n", 
+      sprintf("  Chain %s: E-BFMI = %.3f\n", bad_chains, EBFMIs[bad_chains]),
+      "E-BFMI below 0.2 indicates you may need to reparameterize your model."
+    )
+  }
+}
+
+
+# return a single vector of length chains * iter (post-warmup)
+sampler_param_vector <- function(object, param) {
+  stopifnot(length(param) == 1, is.character(param))
+  sampler_params <- get_sampler_params(object, inc_warmup = FALSE)
+  do.call(rbind, sampler_params)[, param]
+}
+
+# return an iter by chains matrix
+sampler_param_matrix <- function(object, param) {
+  stopifnot(length(param) == 1, is.character(param))
+  sampler_params <- get_sampler_params(object, inc_warmup=FALSE)
+  sapply(sampler_params, function(x) x[, param])
+}

--- a/rstan/rstan/R/check_hmc_diagnostics.R
+++ b/rstan/rstan/R/check_hmc_diagnostics.R
@@ -1,3 +1,9 @@
+
+# Check divergences, treedepth, and energy diagnostics
+#
+# @param object A stanfit object.
+# @return Nothing, just prints the output from the functions it calls internally.
+#
 check_hmc_diagnostics <- function(object) {
   cat("\nDivergences:\n")
     check_divergences(object)

--- a/rstan/rstan/R/check_hmc_diagnostics.R
+++ b/rstan/rstan/R/check_hmc_diagnostics.R
@@ -10,8 +10,8 @@ check_hmc_diagnostics <- function(object) {
 
 # Check transitions that ended with a divergence
 #
-# @param object stanfit object
-# @return nothing, just prints the number (and percentage) of iterations that
+# @param object A stanfit object.
+# @return nothing, just prints the number (and percentage) of iterations that 
 #   ended with a divergence and, if any, suggests increasing adapt_delta.
 #
 check_divergences <- function(object) {
@@ -34,8 +34,8 @@ check_divergences <- function(object) {
 
 # Check transitions that ended prematurely due to maximum tree depth limit
 #
-# @param object stanfit object
-# @return nothing, just prints the number (and percentage) of iterations that
+# @param object A stanfit object.
+# @return Nothing, just prints the number (and percentage) of iterations that
 #   saturated the max treedepth and, if any, suggests increasing max_treedepth.
 #
 check_treedepth <- function(object) {
@@ -64,8 +64,9 @@ check_treedepth <- function(object) {
 
 # Check the energy Bayesian fraction of missing information (E-BFMI)
 #
-# @param object stanfit object
-# @return nothing, just prints
+# @param object A stanfit object.
+# @return Nothing, just prints E-BFMI for chains with low E-BFMI and suggests 
+#   reparameterizing.
 #
 check_energy <- function(object) {
   energies_by_chain <- sampler_param_matrix(object, "energy__")
@@ -87,14 +88,21 @@ check_energy <- function(object) {
 }
 
 
-# return a single vector of length chains * iter (post-warmup)
+# internal ----------------------------------------------------------------
+
+# Extract single sampler parameters in conventient form
+#
+# @param object A stanfit object.
+# @param param The name of a single sampler parameter (e.g. "divergent__").
+# @return sampler_param_vector returns a single vector of length chains * iters
+#   (post-warmup). sampler_param_matrix returns an iters (post-warmup) by chains
+#   matrix.
+#
 sampler_param_vector <- function(object, param) {
   stopifnot(length(param) == 1, is.character(param))
   sampler_params <- get_sampler_params(object, inc_warmup = FALSE)
   do.call(rbind, sampler_params)[, param]
 }
-
-# return an iter by chains matrix
 sampler_param_matrix <- function(object, param) {
   stopifnot(length(param) == 1, is.character(param))
   sampler_params <- get_sampler_params(object, inc_warmup=FALSE)

--- a/rstan/rstan/man/check_hmc_diagnostics.Rd
+++ b/rstan/rstan/man/check_hmc_diagnostics.Rd
@@ -1,0 +1,47 @@
+\name{check_hmc_diagnostics}
+\alias{check_hmc_diagnostics}
+\alias{check_divergences}
+\alias{check_treedepth}
+\alias{check_energy}
+
+\title{Check HMC diagnostics after sampling} 
+
+\description{
+These functions print summaries of important HMC diagnostics.
+The \code{check_hmc_diagnostics} function calls the other functions internally
+and prints an overall summary, but the other functions can also be called 
+directly: 
+\code{check_divergences} prints the number (and percentage) of iterations that
+ended with a divergence, \code{check_treedepth} prints the number (and percentage) of iterations that saturated the max treedepth, and \code{check_energy} 
+prints E-BFMI values for each chain for which E-BFMI is less than 0.2.
+} 
+ 
+\usage{
+check_hmc_diagnostics(object)
+check_divergences(object)
+check_treedepth(object)
+check_energy(object)
+} 
+ 
+\arguments{
+  \item{object}{A stanfit object.}
+} 
+
+\references{
+  The Stan Development Team 
+  \emph{Stan Modeling Language User's Guide and Reference Manual}. 
+  \url{http://mc-stan.org/}. 
+  
+  Betancourt, M. (2017). A conceptual introduction to Hamiltonian Monte Carlo.
+  \url{https://arxiv.org/abs/1701.02434}.
+} 
+
+\examples{
+\dontrun{
+schools <- stan_demo("eight_schools")
+check_hmc_diagnostics(schools)
+check_divergences(schools)
+check_treedepth(schools)
+check_energy(schools)
+}
+} 

--- a/rstan/rstan/man/check_hmc_diagnostics.Rd
+++ b/rstan/rstan/man/check_hmc_diagnostics.Rd
@@ -12,9 +12,15 @@ The \code{check_hmc_diagnostics} function calls the other functions internally
 and prints an overall summary, but the other functions can also be called 
 directly: 
 \code{check_divergences} prints the number (and percentage) of iterations that
-ended with a divergence, \code{check_treedepth} prints the number (and percentage) of iterations that saturated the max treedepth, and \code{check_energy} 
-prints E-BFMI values for each chain for which E-BFMI is less than 0.2.
-} 
+ended with a divergence, \code{check_treedepth} prints the number 
+(and percentage) of iterations that saturated the max treedepth, 
+and \code{check_energy} prints E-BFMI values for each chain for which E-BFMI 
+is less than 0.2.
+
+Brief explanations of some of the problems detected by these diagnostics can
+be found at \url{http://mc-stan.org/misc/warnings.html}. For more depth see
+Betancourt (2017).
+}
  
 \usage{
 check_hmc_diagnostics(object)


### PR DESCRIPTION
#### Summary:

Introduces several functions to print summaries of important HMC diagnostics. These are adapted from code @betanalpha has in his `stan_utility` file.

* `check_hmc_diagnostics` prints an overall summary by calling each of the following functions internally (they can also be called individually since they're all exposed):

* `check_divergences` prints the number (and percentage) of iterations that ended with a divergence 
* `check_treedepth` prints the number (and percentage) of iterations that saturated the max treedepth
* `check_energy` prints E-BFMI values for each chain for which E-BFMI is less than 0.2

#### How to Verify:

```r
# fit model that has some problems
schools <- stan_demo("eight_schools", control = list(max_treedepth = 5)) 
check_hmc_diagnostics(schools)
```

The printed output should look something like this (except in color):

```
Divergences:
145 of 4000 iterations ended with a divergence (3.625%).
Try increasing 'adapt_delta' to remove the divergences.

Tree depth:
277 of 4000 iterations saturated the maximum tree depth of 5 (6.925%).
Try increasing 'max_treedepth' to avoid saturation.

Energy:
E-BFMI indicated possible pathological behavior:
  Chain 1: E-BFMI = 0.171
E-BFMI below 0.2 indicates you may need to reparameterize your model.
```

You can also run the individual check functions: 

```r
check_divergences(schools)
check_treedepth(schools)
check_energy(schools)
```

#### Documentation:

Added doc in `check_hmc_diagnostics.Rd`.

#### Reviewer Suggestions: 

@betanalpha How do these look?

@bgoodri If they look OK to @betanalpha, can we get these in the next release so we have them for courses?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)