### PR TITLE
fix issue #471

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -65,6 +65,7 @@ mklist <- function(names) {
   #   Only extracted are modes of numeric and list, which
   #   are enough for stan
 
+  names <- unique(names)
   cenv <- environment()
   for (fn in rev(sys.parents())) {
     env1 <- sys.frame(fn)
@@ -79,8 +80,8 @@ mklist <- function(names) {
       stop(paste("objects ", paste("'", names[na_idx], "'", collapse = ', ', sep = ''),
                  " of mode numeric and list not found", sep = ''))
     if (numf == length(names))  next
-    r <- c(d1[!na_idx1], d2[!na_idx2])
-    names(r) <- names
+    r <- c(d1[!na_idx1], d2[na_idx1])
+    names(r) <- c(names[!na_idx1], names[na_idx1])
     return(r)
   }
   stop(paste("objects ", paste("'", names, "'", collapse = ', ', sep = ''),

--- a/rstan/tests/unitTests/runit.test.misc.R
+++ b/rstan/tests/unitTests/runit.test.misc.R
@@ -1,11 +1,28 @@
 test_mklist_fun <- function() {
   c <- 4
+  z <- matrix(0, ncol = 2, nrow = 3)
+  x <- list()
+  x[[1]] <- 1:2
+  x[[2]] <- 3:4
+  y <- 3
   fun1 <- function(n) {
     a <- 3
     rstan:::mklist(n)[[n]]
   }
   checkEquals(fun1("a"), 3, checkNames = FALSE)
   checkEquals(fun1("c"), 4, checkNames = FALSE)
+
+  L <- rstan:::mklist(c("y", "z")) # no list
+  checkEquals(L$y, y)
+  checkEquals(L$z, z)
+
+  L <- rstan:::mklist(c("x", "y", "z"))
+  checkEquals(L$x, x)
+  checkEquals(L$y, y)
+  checkEquals(L$z, z)
+
+  L <- rstan:::mklist("x") # only list
+  checkEquals(L$x, x)
 }
 
 test_get_time_from_csv <- function() {


### PR DESCRIPTION
The real reason is a bug in `rstan:::mklist`

#### Summary:
Fix issue #471 (and add new unit tests for it)

The underlying reason is that there is a bug in `mklist`, in which the elements might be wrongly named if some elements are lists. 

#### Intended Effect:

fix the bug

#### How to Verify:

run the unit-test and test the following code
```
library(rstan)
N <- 5
D <- 2
K <- 3
x <- list()
for (i in 1:K) {x[[i]] <- matrix(data=1, nrow=N, ncol=D)}
y <- matrix(data=1, nrow=N, ncol=K)
df <- list(N=N, D=D, K=K, x=x, y=y) # data list

# "Model"
stan_code <- "
data {
    int<lower=0> N;
    int<lower=0> K;
    int<lower=0> D;
    matrix[N, D] x[K];
    int y[N, K];
}
parameters {
  real y0;
}
model {
  y0 ~ normal(0, 1);
}
"
fit <- stan(model_code=stan_code, data=df) # accepts data

fit <- stan(fit = fit, data = c("N", "K", "D", 'x', 'y'))
```

#### Side Effects:
none
#### Documentation:
none
#### Reviewer Suggestions: 
@bgoodri @jgabry 
Just want to make sure it fixes the problem and it does not introduce new bug. 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Jiqiang Guo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
