### PR TITLE
Bugfix/issue#519

### DIFF
--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -364,7 +364,9 @@ setMethod("optimizing", "stanmodel",
             optim$return_code <- attr(optim, "return_code")
             if (optim$return_code != 0) warning("non-zero return code in optimizing")
             attr(optim, "return_code") <- NULL
-            names(optim$par) <- flatnames(m_pars, p_dims, col_major = TRUE)
+            # names(optim$par) <- flatnames(m_pars, p_dims, col_major = TRUE)
+            fnames <- sampler$param_fnames_oi()
+            names(optim$par) <- fnames[1:(length(fnames)-1)]
             skeleton <- create_skeleton(m_pars, p_dims)
             if (hessian || draws) {
               fn <- function(theta) {

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -366,7 +366,7 @@ setMethod("optimizing", "stanmodel",
             attr(optim, "return_code") <- NULL
             # names(optim$par) <- flatnames(m_pars, p_dims, col_major = TRUE)
             fnames <- sampler$param_fnames_oi()
-            names(optim$par) <- fnames[1:(length(fnames)-1)]
+            names(optim$par) <- fnames[-length(fnames)]
             skeleton <- create_skeleton(m_pars, p_dims)
             if (hessian || draws) {
               fn <- function(theta) {

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -1293,10 +1293,8 @@ public:
 
   SEXP param_fnames_oi() const {
     BEGIN_RCPP
-    std::vector<std::string> fnames;
-    get_all_flatnames(names_oi_, dims_oi_, fnames, true);
     SEXP __sexp_result;
-    PROTECT(__sexp_result = Rcpp::wrap(fnames));
+    PROTECT(__sexp_result = Rcpp::wrap(fnames_oi_));
     UNPROTECT(1);
     return __sexp_result;
     END_RCPP

--- a/rstan/tests/unitTests/runit.test.stanmodel.R
+++ b/rstan/tests/unitTests/runit.test.stanmodel.R
@@ -14,7 +14,12 @@ test_optimizing <- function() {
       y ~ normal(0,1); 
       target += -square(a[1]) - square(a[2]);
     }
+    generated quantities {
+      matrix[4, 5] B;
+      for (i in 1:4) for (j in 1:5) B[i,j] = 1;
+    }
   ' 
+  # TODO: add check the names of the returns
   m2 <- stan_model(model_code = mc)
   set.seed(1287)
   o2 <- optimizing(m2, hessian = TRUE, seed = 4)

--- a/rstan/tests/unitTests/runit.test.stanmodel.R
+++ b/rstan/tests/unitTests/runit.test.stanmodel.R
@@ -16,16 +16,21 @@ test_optimizing <- function() {
     }
     generated quantities {
       matrix[4, 5] B;
-      for (i in 1:4) for (j in 1:5) B[i,j] = 1;
+      for (i in 1:4) for (j in 1:5) B[i,j] = i * 10 + j;
     }
   ' 
-  # TODO: add check the names of the returns
+  
   m2 <- stan_model(model_code = mc)
   set.seed(1287)
   o2 <- optimizing(m2, hessian = TRUE, seed = 4)
+  # check the names of the returns
+  checkEquals(o2$par["B[3,4]"], 34, checkNames=FALSE)
+  checkEquals(o2$par["B[1,4]"], 14, checkNames=FALSE)
+  checkEquals(o2$par["B[4,5]"], 45, checkNames=FALSE)
+  checkEquals(o2$par["B[4,1]"], 41, checkNames=FALSE)
   set.seed(1287)
   o3 <- optimizing(m2, as_vector = FALSE, seed = 4)
-  s <- list(a = 1:2, y = 3)
+  s <- list(a = 1:2, y = 3, B = array(0, dim = c(4,5)))
   attr(s$a, "dim") <- 2
   checkEquals(o3$par, rstan:::rstan_relist(o2$par, s))
   checkEquals(o2$par[3], 0, tolerance = 0.1, checkNames = FALSE)


### PR DESCRIPTION
#### Summary:

reduce the time spent on creating the names for the return vector from optimizing. 

#### Intended Effect:

much faster.  However, as the vector and the names are first stored in c++ vector and later copied to R's vector, it still takes some extra time.  

#### How to Verify:

run the code in issue #519 under currently released version and this fix. 

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Jiqiang Guo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
