### PR TITLE
CSV speed improvements and support for large CSV files

### DIFF
--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -130,24 +130,56 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     stop("csvfiles does not contain any CSV file name")
 
   g_skip <- 10
-  g_max_comm <- -1 # to read all 
-
-  cs_lst <- lapply(csvfiles, function(csv) read_comments(csv, n = g_max_comm))
-  cs_lst2 <- lapply(cs_lst, parse_stancsv_comments)
   
   ss_lst <- vector("list", length(csvfiles))
+  cs_lst2 <- vector("list", length(csvfiles))
+
   for (i in seq_along(csvfiles)) {
     header <- read_csv_header(csvfiles[i])
     lineno <- attr(header, 'lineno')
     vnames <- strsplit(header, ",")[[1]]
-    m <- matrix(scan(csvfiles[i], skip = lineno, comment.char = '#', sep = ',', quiet = TRUE),
-                ncol = length(vnames), byrow = TRUE)
-    ss_lst[[i]] <- as.data.frame(m)
-    colnames(ss_lst[[i]]) <- vnames 
+    iter.count <- attr(header,"iter.count")
+    variable.count <- length(vnames)
+    df <- structure(replicate(variable.count,list(numeric(iter.count))),
+                    names = vnames,
+                    row.names = c(NA,-iter.count),
+                    class = "data.frame")
+    comments = character()
+    con <- file(csvfiles[[i]],"r")
+    buffer.size <- min(ceiling(1000000/variable.count),iter.count)
+    row.buffer <- matrix(ncol=variable.count,nrow=buffer.size)
+    row <- 1
+    buffer.pointer <- 1  
+    while(length(char <- readChar(con, 1)) > 0) {
+      # back up 1 character, since we already looked at one to check for comment
+      seek(con,origin="current",-1)
+      if(char == "#"){
+        line <- readLines(con, n = 1)
+        comments <- c(comments, line)
+        next
+      }
+      if(char == "l"){ #start of lp__ in header
+        readLines(con, n = 1)
+        next
+      }
+      row.buffer[buffer.pointer,] <- scan(con, nlines=1, sep="," ,quiet=TRUE)
+      if(buffer.pointer == buffer.size){
+        df[row:(row + buffer.size - 1), ] <- row.buffer
+        row <- row + buffer.size
+        buffer.pointer <- 0
+      }
+      buffer.pointer <- buffer.pointer + 1
+      
+    }
+    if(buffer.pointer > 1){
+      df[row:(row + buffer.pointer - 2), ] <- row.buffer[1:(buffer.pointer-1), ]
+    }
+
+    close(con)
+    cs_lst2[[i]] <- parse_stancsv_comments(comments)
+    ss_lst[[i]] <- df
   } 
 
-  ## read.csv is slow for large files 
-  ##ss_lst <- lapply(csvfiles, function(csv) read.csv(csv, header = TRUE, skip = 10, comment.char = '#'))
   # use the first CSV file name as model name
   m_name <- sub("(_\\d+)*$", '', filename_rm_ext(basename(csvfiles[1])))
 
@@ -207,7 +239,6 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     warmup2 <- 1 + (warmup[1] - 1) %/% thin[1]
     n_kept <- n_save - warmup2 
   } 
-  
   if (n_kept0[1] != n_kept) {
     warning("the number of iterations after warmup found (", n_kept, 
             ") does not match iter/warmup/thin from CSV comments (",

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -152,17 +152,17 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     buffer.pointer <- 1  
     while(length(char <- readChar(con, 1)) > 0) {
       # back up 1 character, since we already looked at one to check for comment
-      if(getRversion() == "3.5.0") seek(con,seek(con)-1)
+      if(getRversion() >="3.5.0") seek(con,seek(con)-1)
       else seek(con,origin="current",-1)
       if(char == "#"){
         line <- readLines(con, n = 1)
-        if(getRversion() == "3.5.0") seek(con,seek(con))
+        if(getRversion() >="3.5.0") seek(con,seek(con))
         comments <- c(comments, line)
         next
       }
       if(char == "l"){ #start of lp__ in header
         readLines(con, n = 1)
-        if(getRversion() == "3.5.0") seek(con,seek(con))
+        if(getRversion() >="3.5.0") seek(con,seek(con))
         next
       }
       row.buffer[buffer.pointer,] <- scan(con, nlines=1, sep="," ,quiet=TRUE)

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -152,17 +152,21 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     buffer.pointer <- 1  
     while(length(char <- readChar(con, 1)) > 0) {
       # back up 1 character, since we already looked at one to check for comment
-      seek(con,origin="current",-1)
+      if(getRversion() == "3.5.0") seek(con,seek(con)-1)
+      else seek(con,origin="current",-1)
       if(char == "#"){
         line <- readLines(con, n = 1)
+        if(getRversion() == "3.5.0") seek(con,seek(con))
         comments <- c(comments, line)
         next
       }
       if(char == "l"){ #start of lp__ in header
         readLines(con, n = 1)
+        if(getRversion() == "3.5.0") seek(con,seek(con))
         next
       }
       row.buffer[buffer.pointer,] <- scan(con, nlines=1, sep="," ,quiet=TRUE)
+        seek(con,seek(con))
       if(buffer.pointer == buffer.size){
         df[row:(row + buffer.size - 1), ] <- row.buffer
         row <- row + buffer.size

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -260,7 +260,7 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
 
   idx_kept <- if (warmup2 == 0) 1:n_kept else -(1:warmup2)
   for (i in seq_along(samples)) {
-    m <- apply(samples[[i]][idx_kept,], 2, mean)
+    m <- vapply(samples[[i]], function(x) mean(x[idx_kept]), numeric(1))
     attr(samples[[i]], "mean_pars") <- m[-length(m)]
     attr(samples[[i]], "mean_lp__") <- m["lp__"]
   }

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -145,28 +145,24 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
                     row.names = c(NA,-iter.count),
                     class = "data.frame")
     comments = character()
-    con <- file(csvfiles[[i]],"r")
+    con <- file(csvfiles[[i]],"rb")
     buffer.size <- min(ceiling(1000000/variable.count),iter.count)
     row.buffer <- matrix(ncol=variable.count,nrow=buffer.size)
     row <- 1
     buffer.pointer <- 1  
-    while(length(char <- readChar(con, 1)) > 0) {
+    while(length(char <- readBin(con,'int',size=1L)) > 0) {
       # back up 1 character, since we already looked at one to check for comment
-      if(getRversion() >="3.5.0") seek(con,seek(con)-1)
-      else seek(con,origin="current",-1)
-      if(char == "#"){
+      seek(con,origin="current",-1)
+      if(char == 35){ #35 is '#'
         line <- readLines(con, n = 1)
-        if(getRversion() >="3.5.0") seek(con,seek(con))
         comments <- c(comments, line)
         next
       }
-      if(char == "l"){ #start of lp__ in header
+      if(char == 108){ #start of lp__ in header 108
         readLines(con, n = 1)
-        if(getRversion() >="3.5.0") seek(con,seek(con))
         next
       }
       row.buffer[buffer.pointer,] <- scan(con, nlines=1, sep="," ,quiet=TRUE)
-        seek(con,seek(con))
       if(buffer.pointer == buffer.size){
         df[row:(row + buffer.size - 1), ] <- row.buffer
         row <- row + buffer.size


### PR DESCRIPTION
#### Summary:

Read in CSVs line by line so that CSV files with more than
INT_MAX entries can be supported properly, since base R's
scan function does not have long vector support.

This is also saves more performant since we can preallocate
the data.frame, and fill it in row by row, rather than
reading in the entire CSV, converting it into a matrix,
and then into a data.frame. We also read the comment lines
and data lines in one pass through the file rather than
separate passes.

#### Intended Effect:

Fix limit on read_stan_csv (https://github.com/stan-dev/rstan/issues/530) without requiring a patch to base R. 

#### Side Effects:

Faster to read in CSV files even when they do not exceed the max size limit.

#### How to Verify:

Create large file via CMDStan and read in with read_stan_csv. 
Reading 100 iterations from the following model:
```
parameters {
  vector[10000] theta;
} 
model {
  target += -0.5*dot_self(theta);
}
```

Old:
> system.time(x <- read_stan_csv("output.csv"))
   user  system elapsed 
  3.333   0.056   5.191

New:
> system.time(x <- read_stan_csv("output.csv"))
   user  system elapsed 
  2.148   0.049   3.409 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aaron Goodman

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
