### PR TITLE
issue #535, use symbols rather than strings for C functions

### DIFF
--- a/rstan/rstan/R/chains.R
+++ b/rstan/rstan/R/chains.R
@@ -18,7 +18,7 @@
 rstan_ess <- function(sim, n) {
   # Args:
   #   n: Chain index starting from 1.
-  ess <- .Call("effective_sample_size", sim, n - 1)
+  ess <- .Call(effective_sample_size, sim, n - 1)
   ess
 } 
 
@@ -26,21 +26,21 @@ rstan_splitrhat <- function(sim, n) {
   # Args:
   #   n: Chain index starting from 1.
   if (sim$n_save[1] - sim$warmup2[1] < 2) return(NaN)
-  rhat <- .Call("split_potential_scale_reduction", sim, n - 1)
+  rhat <- .Call(split_potential_scale_reduction, sim, n - 1)
   rhat
 }
 
 rstan_splitrhat2_cpp <- function(sims) {
   # Args:
   #   sim: samples of several chains _without_ warmup
-  rhat <- .Call("split_potential_scale_reduction2", sims)
+  rhat <- .Call(split_potential_scale_reduction2, sims)
   rhat
 }
 
 rstan_ess2_cpp <- function(sims) {
   # Args:
   #   sim: samples of several chains _without_ warmup
-  ess <- .Call("effective_sample_size2", sims)
+  ess <- .Call(effective_sample_size2, sims)
   ess
 } 
 
@@ -52,6 +52,6 @@ rstan_seq_perm <- function(n, chains, seed, chain_id = 1) {
   #   chain_id: the chain id, for which the returned permuation is applied 
   # 
   conf <- list(n = n, chains = chains, seed = seed, chain_id = chain_id) 
-  perm <- .Call("seq_permutation", conf)
+  perm <- .Call(seq_permutation, conf)
   perm + 1L # start from 1 
 } 

--- a/rstan/rstan/R/extract_sparse_parts.R
+++ b/rstan/rstan/R/extract_sparse_parts.R
@@ -22,5 +22,5 @@ extract_sparse_parts <- function(A) {
     A <- Matrix::Matrix(A, sparse=TRUE)
   A <- Matrix::t(A)
   A <- as(A, "dgCMatrix")
-  return(.Call("extract_sparse_components", A))
+  return(.Call(extract_sparse_components, A))
 }

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1384,7 +1384,7 @@ makeconf_path <- function() {
 }
 
 is_null_ptr <- function(ns) {
-  .Call("is_Null_NS", ns)
+  .Call(is_Null_NS, ns)
 }
 
 is_null_cxxfun <- function(cx) {
@@ -1392,7 +1392,7 @@ is_null_cxxfun <- function(cx) {
   # contains null pointer
   add <- body(cx@.Data)[[2]]
   # add is of class NativeSymbol
-  .Call("is_Null_NS", add)
+  .Call(is_Null_NS, add)
 }
 
 obj_size_str <- function(x) {
@@ -1414,7 +1414,7 @@ read_comments_old <- function(file, n) {
   # Args:
   #   file: the filename
   #   n: max number of line; -1 means all
-  .Call("CPP_read_comments", file, n)
+  .Call(CPP_read_comments, file, n)
 }
 
 read_comments <- function(f, n = -1) {

--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -35,7 +35,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model",
   
   # model_name in C++, to avoid names that would be problematic in C++. 
   model_cppname <- legitimate_model_name(model_name, obfuscate_name = obfuscate_model_name) 
-  r <- .Call("CPP_stanc280", model_code, model_cppname, allow_undefined, isystem)
+  r <- .Call(CPP_stanc280, model_code, model_cppname, allow_undefined, isystem)
   # from the cpp code of stanc,
   # returned is a named list with element 'status', 'model_cppname', and 'cppcode' 
   r$model_name <- model_name  
@@ -62,7 +62,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model",
 
 
 stan_version <- function() {
-  .Call('CPP_stan_version')
+  .Call(CPP_stan_version)
 }
 
 rstudio_stanc <- function(filename) {

--- a/rstan/rstan/man/rstan.Rd
+++ b/rstan/rstan/man/rstan.Rd
@@ -114,7 +114,7 @@ fit <- stan(model_code = stanmodelcode, model_name = "example",
 print(fit)
 
 # extract samples 
-e <- extract(fit, permuted = FALSE) # return a list of arrays 
+e <- extract(fit, permuted = TRUE) # return a list of arrays
 mu <- e$mu 
 
 arr <- as.array(fit) # return an array 


### PR DESCRIPTION
#### Summary:

Fix issue #535, using symbols rather than strings to call C functions

#### Intended Effect:

The following code should run without issue:
```
library(Matrix)
library(rstan)
detach("package:Matrix", unload=TRUE)
example(rstan, run.dontrun=TRUE)
```


#### How to Verify:

Run above code

#### Side Effects:
none
#### Documentation:
not needed
#### Reviewer Suggestions: 
@bgoodri 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Jiqiang Guo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
