### PR TITLE
Bugfix/segfault issue540

### DIFF
--- a/rstan/rstan/inst/unitTests/runit.test.chains.R
+++ b/rstan/rstan/inst/unitTests/runit.test.chains.R
@@ -37,6 +37,8 @@ test_ess2 <- function() {
               warmup2 = rep(17, 2),
               chains = 2, 
               n_flatnames = 2)
+  # just make sure this can run without segfault first
+  ess <- rstan:::rstan_ess(lst, 1)
   ess <- rstan:::rstan_ess(lst, 2)
 }
 

--- a/rstan/rstan/inst/unitTests/runit.test.chains.R
+++ b/rstan/rstan/inst/unitTests/runit.test.chains.R
@@ -32,14 +32,19 @@ test_ess2 <- function() {
   x2 <- list(x = x21, y = rep(1, length(x21)))
 
   lst <- list(samples = list(c1=x1, c2=x2),
-              n_save = c(34, 2),
+              n_save = rep(34, 2),
               permutation = NULL,
               warmup2 = rep(17, 2),
               chains = 2, 
               n_flatnames = 2)
+
   # just make sure this can run without segfault first
   ess <- rstan:::rstan_ess(lst, 1)
   ess <- rstan:::rstan_ess(lst, 2)
+
+  # this is NaN because variable rho_hat_odd in function
+  # effective_sample_size in ../../src/chains.cpp is NaN and then max_t=1
+  checkTrue(is.nan(ess))
 }
 
 test_essnrhat <- function() {

--- a/rstan/rstan/src/chains.cpp
+++ b/rstan/rstan/src/chains.cpp
@@ -138,6 +138,22 @@ namespace rstan {
             << ", but INTSXP/REALSXP needed";
         throw std::domain_error(msg.str());
       }
+
+      SEXP sample_sexp = lst["samples"];
+
+      if (TYPEOF(lst["samples"]) != VECSXP) {
+        std::stringstream msg;
+        msg << "sim$samples is not a list";
+        throw std::domain_error(msg.str());
+      }
+
+      int nchains2 = Rcpp::List(sample_sexp).size();
+      if (nchains2 != Rcpp::as<int>(lst["chains"])) {
+        std::stringstream msg;
+        msg << "the number of chains specified is different from "
+            << "the one found in samples";
+        throw std::domain_error(msg.str());
+      }
     }
 
     unsigned int num_chains(SEXP sim) {
@@ -157,11 +173,6 @@ namespace rstan {
     void get_kept_samples(SEXP sim, const size_t k, const size_t n,
                           std::vector<double>& samples) {
       Rcpp::List lst(sim);
-      if (TYPEOF(lst["samples"]) != VECSXP) {
-        std::stringstream msg;
-        msg << "sim$samples is not a list";
-        throw std::domain_error(msg.str());
-      }
       Rcpp::List allsamples(static_cast<SEXP>(lst["samples"]));
       Rcpp::IntegerVector n_save(static_cast<SEXP>(lst["n_save"]));
       Rcpp::IntegerVector warmup2(static_cast<SEXP>(lst["warmup2"]));

--- a/rstan/rstan/src/chains.cpp
+++ b/rstan/rstan/src/chains.cpp
@@ -348,7 +348,6 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
   }
 
   double rho_hat_even = 1;
-  rho_hat_t[0] = rho_hat_even;
   double rho_hat_odd = 1 - (mean_var - stan::math::mean(acov_t)) / var_plus;
   rho_hat_t[1] = rho_hat_odd;
   // Geyer's initial positive sequence

--- a/rstan/rstan/src/chains.cpp
+++ b/rstan/rstan/src/chains.cpp
@@ -337,21 +337,23 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
     chain_mean.push_back(rstan::get_chain_mean(sim,chain,n));
     chain_var.push_back(acov[chain][0]*n_kept_samples/(n_kept_samples-1));
   }
+
   double mean_var = stan::math::mean(chain_var);
   double var_plus = mean_var*(n_samples-1)/n_samples;
   if (m > 1) var_plus += stan::math::variance(chain_mean);
-  vector<double> rho_hat_t;
+  vector<double> rho_hat_t(n_samples, 0);
   vector<double> acov_t(m);
   for (size_t chain = 0; chain < m; chain++) {
     acov_t[chain] = acov[chain][1];
   }
+
   double rho_hat_even = 1;
-  rho_hat_t.push_back(rho_hat_even);
+  rho_hat_t[0] = rho_hat_even;
   double rho_hat_odd = 1 - (mean_var - stan::math::mean(acov_t)) / var_plus;
-  rho_hat_t.push_back(rho_hat_odd);
+  rho_hat_t[1] = rho_hat_odd;
   // Geyer's initial positive sequence
   int max_t = 1;
-  for (size_t t = 1;
+  for (int t = 1;
        (t < (n_samples - 2) && (rho_hat_even + rho_hat_odd) >= 0);
        t += 2) {
     for (int chain = 0; chain < m; chain++)
@@ -361,22 +363,22 @@ SEXP effective_sample_size(SEXP sim, SEXP n_) {
       acov_t[chain] = acov[chain][t + 2];
     rho_hat_odd = 1 - (mean_var - stan::math::mean(acov_t)) / var_plus;
     if ((rho_hat_even + rho_hat_odd) >= 0) {
-      rho_hat_t.push_back(rho_hat_even);
-      rho_hat_t.push_back(rho_hat_odd);
+      rho_hat_t[t+1] = rho_hat_even;
+      rho_hat_t[t+2] = rho_hat_odd;
     }
     max_t = t + 2;
   }
+
   // Geyer's initial monotone sequence
-  for (size_t t = 3; t <= max_t - 2; t += 2) {
-    if (rho_hat_t[t + 1] + rho_hat_t[t + 2] >
-  	rho_hat_t[t - 1] + rho_hat_t[t]) {
+  for (int t = 3; t <= max_t - 2; t += 2) {
+    if (rho_hat_t[t + 1] + rho_hat_t[t + 2] > rho_hat_t[t - 1] + rho_hat_t[t]) {
       rho_hat_t[t + 1] = (rho_hat_t[t - 1] + rho_hat_t[t]) / 2;
       rho_hat_t[t + 2] = rho_hat_t[t + 1];
     }
   }
 
   double ess = m*n_samples;
-  ess /= (-1 + 2 * stan::math::sum(rho_hat_t));
+  ess /= (1 + 2 * stan::math::sum(rho_hat_t));
   SEXP __sexp_result;
   PROTECT(__sexp_result = Rcpp::wrap(ess));
   UNPROTECT(1);

--- a/rstan/tests/runRunitTests.R
+++ b/rstan/tests/runRunitTests.R
@@ -12,8 +12,8 @@ if (!require("RUnit", quietly = TRUE)) {
 if (exists("path")) { 
   reportfile <- file.path(getwd(), "report")
 } else {
-   path <- getwd() 
-   reportfile <- file.path(path, "report") 
+  path <- getwd()
+  reportfile <- file.path(path, "report")
 } 
 
 stopifnot(file.exists(path), file.info(path.expand(path))$isdir)
@@ -24,7 +24,8 @@ if (length(args) > 0)  rstan_lib_loc <- args[1]
 library(package = pkg, character.only = TRUE, lib.loc = rstan_lib_loc)
 
 rstantest <- defineTestSuite("rstantest",
-                             dirs = file.path(path, "unitTests"),
+                             dirs = c(file.path(path, "unitTests"),
+                                      system.file(package = 'rstan', "unitTests")),
                              testFileRegexp = "^runit.+.*\\.R",
                              testFuncRegexp = "^test_+",
                              rngKind = "Marsaglia-Multicarry",


### PR DESCRIPTION
#### Summary:

This fixes the segfault occurred in running unit tests.  Essentially, only a change of using type int in a for loop rather than size_t is really needed in the C++ code.

And more tests are added.  

#### Intended Effect:

#### How to Verify:

run the whole unit tests (travis-ci builds successfully now) 

or run the example in issue #540 

#### Side Effects:

none

#### Documentation:

#### Reviewer Suggestions: 
@bgoodri @avehtari 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Jiqiang Guo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
