### PR TITLE
Update stan_plot_helpers.R

### DIFF
--- a/rstan/rstan/R/stan_plot_helpers.R
+++ b/rstan/rstan/R/stan_plot_helpers.R
@@ -178,7 +178,7 @@ is.stanfit <- function(x) inherits(x, "stanfit")
   }
   
   dat <- .reshape_sample(samp_use)
-  dat$iteration <- idx
+  dat$iteration <- idx * thin
   dat$chain <- factor(dat$chain)
   fnames <- if (unconstrain) 
     names(samp_use[[1]]) else sim$fnames_oi[tidx]


### PR DESCRIPTION
Fixes issue with the x axis of stan_trace plot not matching

#### Summary:
If the stan model was thinned the trace plot x axis did not match, by multiplying the iteractions by the thin factor it now works

#### Intended Effect:
Make the x axis of stan_trace plot match the number of iteractions

#### How to Verify:
Run this code and check the x axis
```r
library(rstan)
scode <- "
parameters {
real y[2]; 
} 
model {
y[1] ~ normal(0, 1);
y[2] ~ double_exponential(0, 2);
} 
"
fit1 <- stan(model_code = scode, iter = 10, verbose = FALSE) 
print(fit1)
fit2 <- stan(fit = fit1, iter = 10000, verbose = FALSE)
fit3 <- stan(fit = fit1, iter = 10000, verbose = FALSE, thin=3) 
stan_trace(fit2)
stan_trace(fit3)
stan_trace(fit2, inc_warmup = T)
stan_trace(fit3, inc_warmup = T)
```
#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
