### PR TITLE
Bugfix/issue 550 postfix lp

### DIFF
--- a/rstan/rstan/NAMESPACE
+++ b/rstan/rstan/NAMESPACE
@@ -65,7 +65,7 @@ export(
   get_low_bfmi_chains,
   get_rng,
   get_stream,
-  RNG, OUT
+  RNG, OUT, ACC
 )
 
 exportClasses(

--- a/rstan/rstan/NAMESPACE
+++ b/rstan/rstan/NAMESPACE
@@ -65,6 +65,8 @@ export(
   get_low_bfmi_chains,
   get_rng,
   get_stream,
+  get_accumulator,
+  check_accumulator,
   RNG, OUT, ACC
 )
 

--- a/rstan/rstan/R/get_accumulator.R
+++ b/rstan/rstan/R/get_accumulator.R
@@ -1,0 +1,10 @@
+get_rng <- function(start=0L) {
+  if (start != 0L) {
+    if (length(start) != 1) 
+      stop("Start value must be a length-1 integer vector.")
+  }
+  return(.Call('get_accumulator_', start))
+}
+
+
+

--- a/rstan/rstan/R/get_accumulator.R
+++ b/rstan/rstan/R/get_accumulator.R
@@ -1,9 +1,13 @@
-get_rng <- function(start=0L) {
+get_accumulator <- function(start=0L) {
   if (start != 0L) {
     if (length(start) != 1) 
       stop("Start value must be a length-1 integer vector.")
   }
   return(.Call('get_accumulator_', start))
+}
+
+check_accumulator <- function(accumulator = ACC) {
+  return(.Call('check_accumulator_', accumulator))
 }
 
 

--- a/rstan/rstan/R/get_accumulator.R
+++ b/rstan/rstan/R/get_accumulator.R
@@ -1,9 +1,5 @@
-get_accumulator <- function(start=0L) {
-  if (start != 0L) {
-    if (length(start) != 1) 
-      stop("Start value must be a length-1 integer vector.")
-  }
-  return(.Call('get_accumulator_', start))
+get_accumulator <- function() {
+  return(.Call('get_accumulator_'))
 }
 
 check_accumulator <- function(accumulator = ACC) {

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -24,7 +24,7 @@ ACC <- 0
   assignInMyNamespace("rstan_load_time", value = Sys.time())  
   assignInMyNamespace("RNG", value = get_rng(0))
   assignInMyNamespace("OUT", value = get_stream())
-  assignInMyNamespace("ACC", value = get_accumulator(0))
+  assignInMyNamespace("ACC", value = get_accumulator())
 }
 
 .onAttach <- function(...) {

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -18,11 +18,13 @@
 rstan_load_time <- as.POSIXct("1970-01-01 00:00.00 UTC")
 RNG <- 0
 OUT <- 0
+ACC <- 0
 
 .onLoad <- function(libname, pkgname) {
   assignInMyNamespace("rstan_load_time", value = Sys.time())  
   assignInMyNamespace("RNG", value = get_rng(0))
   assignInMyNamespace("OUT", value = get_stream())
+  assignInMyNamespace("ACC", value = get_accumulator(0))
 }
 
 .onAttach <- function(...) {

--- a/rstan/rstan/inst/include/exporter.h
+++ b/rstan/rstan/inst/include/exporter.h
@@ -79,7 +79,7 @@ namespace Rcpp {
       inline boost::ecuyer1988& get(){ return t ; }
     private:
       boost::ecuyer1988& t ;
-    } ; 
+    }; 
 
     template <> class Exporter<stan::math::accumulator<double>&> {
     public:
@@ -87,7 +87,7 @@ namespace Rcpp {
       inline stan::math::accumulator<double>& get(){ return t ; }
     private:
       stan::math::accumulator<double>& t ;
-    } ; 
+    }; 
 
     template <>
     struct input_parameter<boost::ecuyer1988&> {

--- a/rstan/rstan/inst/include/exporter.h
+++ b/rstan/rstan/inst/include/exporter.h
@@ -1,17 +1,22 @@
 #include <RcppCommon.h>
 #include <boost/random/additive_combine.hpp>
+#include <stan/math/prim/mat/fun/accumulator.hpp>
 #include <iostream>
 
 namespace Rcpp {
   SEXP wrap(boost::ecuyer1988 RNG);
   SEXP wrap(boost::ecuyer1988& RNG);
+  SEXP wrap(stan::math::accumulator<double>& RNG);
   SEXP wrap(std::ostream stream);
   template <> boost::ecuyer1988 as(SEXP ptr_RNG);
   template <> boost::ecuyer1988& as(SEXP ptr_RNG);
+  template <> stan::math::accumulator<double>& as(SEXP ptr_acc);
   template <> std::ostream* as(SEXP ptr_stream);
   namespace traits {
     template <> class Exporter<boost::ecuyer1988&>;
     template <> struct input_parameter<boost::ecuyer1988&>;
+    template <> class Exporter<stan::math::accumulator<double>&>;
+    template <> struct input_parameter<stan::math::accumulator<double>&>;
   }
 }
 
@@ -31,6 +36,12 @@ namespace Rcpp {
     return Xptr_RNG;
   }
 
+  SEXP wrap(stan::math::accumulator<double>& ACC){
+    stan::math::accumulator<double>* ptr_ACC = &ACC;
+    Rcpp::XPtr<stan::math::accumulator<double>> Xptr_ACC(ptr_ACC);
+    return Xptr_ACC;
+  }
+
   SEXP wrap(std::ostream stream) {
     std::ostream* ptr_stream = &stream;
     Rcpp::XPtr<std::ostream> Xptr_stream(ptr_stream);
@@ -40,13 +51,19 @@ namespace Rcpp {
   template <> boost::ecuyer1988 as(SEXP ptr_RNG) {
     Rcpp::XPtr<boost::ecuyer1988> ptr(ptr_RNG);
     boost::ecuyer1988& RNG = *ptr; 
- 		return RNG;
+    return RNG;
   }
 
   template <> boost::ecuyer1988& as(SEXP ptr_RNG) {
     Rcpp::XPtr<boost::ecuyer1988> ptr(ptr_RNG);
     boost::ecuyer1988& RNG = *ptr; 
- 		return RNG;
+    return RNG;
+  }
+
+  template <> stan::math::accumulator<double>& as(SEXP ptr_ACC) {
+    Rcpp::XPtr<stan::math::accumulator<double>> ptr(ptr_ACC);
+    stan::math::accumulator<double>& ACC = *ptr; 
+    return ACC;
   }
 
   template <> std::ostream* as(SEXP ptr_stream) {
@@ -64,10 +81,22 @@ namespace Rcpp {
       boost::ecuyer1988& t ;
     } ; 
 
+    template <> class Exporter<stan::math::accumulator<double>&> {
+    public:
+      Exporter( SEXP x ) : t(Rcpp::as<stan::math::accumulator<double>&>(x)) {}
+      inline stan::math::accumulator<double>& get(){ return t ; }
+    private:
+      stan::math::accumulator<double>& t ;
+    } ; 
+
     template <>
     struct input_parameter<boost::ecuyer1988&> {
       typedef typename Rcpp::ConstReferenceInputParameter<boost::ecuyer1988&> type ;
-      //typedef typename boost::ecuyer1988& type ;
+    };
+
+    template <>
+    struct input_parameter<stan::math::accumulator<double>&> {
+      typedef typename Rcpp::ConstReferenceInputParameter<stan::math::accumulator<double>&> type ;
     };
   }
 

--- a/rstan/rstan/src/init.cpp
+++ b/rstan/rstan/src/init.cpp
@@ -46,6 +46,8 @@ SEXP CPP_stan_version();
 SEXP extract_sparse_components(SEXP A);
 SEXP get_rng_(SEXP seed);
 SEXP get_stream_();
+SEXP get_accumulator_();
+SEXP check_accumulator_(SEXP ptr_ACC);
 
 #ifdef __cplusplus
 }
@@ -68,6 +70,8 @@ static const R_CallMethodDef CallEntries[] = {
   CALLDEF(extract_sparse_components, 1),
   CALLDEF(get_rng_, 1),
   CALLDEF(get_stream_, 0),
+  CALLDEF(get_accumulator_, 0),
+  CALLDEF(check_accumulator_, 1),
   {NULL, NULL, 0}
 };
 

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <boost/random/additive_combine.hpp>
+#include <stan/math/prim/math/fun/accumulator.hpp>
 
 RcppExport SEXP get_stream_() {
   std::ostream* pstream(&Rcpp::Rcout);
@@ -11,6 +12,13 @@ RcppExport SEXP get_rng_(SEXP seed) {
   int seed_ = Rcpp::as<int>(seed);
   boost::ecuyer1988* rng = new boost::ecuyer1988(seed_);
   Rcpp::XPtr<boost::ecuyer1988> ptr(rng, true);
+  return ptr;
+}
+
+RcppExport SEXP get_accumulator_(SEXP start) {
+  int start_ = Rcpp::as<int>(start);
+  stan::math::accumulator<double>* acc = new stan::math::accumulator<double>(start_);
+  Rcpp::XPtr<stan::math::accumulator<double>> ptr(acc, true);
   return ptr;
 }
 

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -1,6 +1,6 @@
 #include <Rcpp.h>
 #include <boost/random/additive_combine.hpp>
-#include <stan/math/prim/math/fun/accumulator.hpp>
+#include <stan/math/prim/mat/fun/accumulator.hpp>
 
 RcppExport SEXP get_stream_() {
   std::ostream* pstream(&Rcpp::Rcout);
@@ -15,18 +15,17 @@ RcppExport SEXP get_rng_(SEXP seed) {
   return ptr;
 }
 
-RcppExport SEXP get_accumulator_(SEXP start) {
-  int start_ = Rcpp::as<int>(start);
-  stan::math::accumulator<double>* acc = new stan::math::accumulator<double>(start_);
+RcppExport SEXP get_accumulator_() {
+  stan::math::accumulator<double>* acc = new stan::math::accumulator<double>();
   Rcpp::XPtr<stan::math::accumulator<double>> ptr(acc, true);
   return ptr;
 }
 
 RcppExport SEXP check_accumulator_(SEXP ptr_ACC) {
-  Rcpp::XPtr<stan::math::accumulator<double>> ptr(ptr_ACC, true);
+  Rcpp::XPtr<stan::math::accumulator<double>> ptr(ptr_ACC);
   stan::math::accumulator<double>& acc = *ptr;
   double total = acc.sum();
-  return total;
+  return Rcpp::wrap(total);
 }
 
 

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -22,4 +22,11 @@ RcppExport SEXP get_accumulator_(SEXP start) {
   return ptr;
 }
 
+RcppExport SEXP check_accumulator_(SEXP ptr_ACC) {
+  Rcpp::XPtr<stan::math::accumulator<double>> ptr(ptr_ACC, true);
+  stan::math::accumulator<double>& acc = *ptr;
+  double total = acc.sum();
+  return total;
+}
+
 


### PR DESCRIPTION
#### Summary:

Makes expose_stan_functions work on functions with _lp postfix

#### Intended Effect:

Add R-side:
  - get_accumulator for exposing and managing destruction of a stan::math::accumulator<double> object.  Accumulator object is destroyed when the R object is destroyed
  - check_accumulator(acc) returns the current value of the sum of accumulated objects
  - ACC global object holding an accumulator that's ready to use
 
C++-side:
  - in exporter.h make it possible to take arguments for Rcpp to convert to stan::math::accumulator and return same as an Rcpp::XPtr to R-side

#### How to Verify:

Install and run: 

```
library(rstan)
check_accumulator(ACC)
expose_stan_functions('model.stan')
foo_lp(0, ACC, OUT)
check_accumulator(ACC)
acc = get_accumulator()
foo_lp(0, acc, OUT)
check_accumulator(acc)
```


#### Side Effects:

None?

#### Documentation:

None right now, let me know what doc you want if you want it.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Krzysztof Sakrejda

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
