### PR TITLE
Ensure cmd.exe is on the path on windows

### DIFF
--- a/rstan/rstan/R/rstan.R
+++ b/rstan/rstan/R/rstan.R
@@ -172,7 +172,18 @@ stan_model <- function(file,
     writeLines(model_code, con = unprocessed)
     ARGS <- paste("-E -nostdinc -x c++ -P -C", paste("-I", isystem, " ", collapse = ""), 
                   "-o", processed, unprocessed)
-    pkgbuild::with_build_tools(system2(CXX, args = ARGS), 
+    
+    env <- character()
+    if (Sys.info()['sysname'] == 'Windows') {
+      # Ensure cmd.exe is on the PATH
+      win_root <- Sys.getenv('SystemRoot', 'C:\\Windows')
+      path <- Sys.getenv('PATH')
+      win_utils_path <- paste0(win_root, '\\', 'System32')
+      new_path <- paste0(path, ';', win_utils_path)
+      env <- c(PATH=new_path)
+    }
+      
+    pkgbuild::with_build_tools(system2(CXX, args = ARGS, env = env), 
                                required = rstan_options("required") && 
                                   identical(Sys.getenv("WINDOWS"), "TRUE") &&
                                  !identical(Sys.getenv("R_PACKAGE_SOURCE"), "") )


### PR DESCRIPTION
Fixes stan-dev/rstan#584

#### Summary:

on windows, If `cmd.exe` isn't on the path (i.e. `C:\\Windows\\System32`) then stan fails, throwing a cryptic error. this adds `C:\\Windows\\System32` to the path in case it is missing.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

jonathon love

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

yes.