### PR TITLE
Fix to read_stan_csv to parse vb

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1518,6 +1518,9 @@ read_csv_header <- function(f, comment.char = '#') {
     if (grepl("#.*save_warmup",input)){
       save.warmup <- !grepl("0",input)
     }
+    if (grepl("#.*output_sample",input)){
+      iter.count <- as.numeric(gsub("[^0-9]*([0-9]*).*","\\1",input))
+    }
 
   }
   header <- input

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -114,7 +114,7 @@ parse_stancsv_comments <- function(comments) {
   for (z in names1) values[[z]] <- as.integer(values[[z]])
   for (z in names2) values[[z]] <- as.numeric(values[[z]])
   if (compute_iter) values[["iter"]] <- values[["iter"]] + values[["warmup"]]
-  if (values$method == "variational"){ ## fix missing values for variational 
+  if ("output_samples" %in% names(values)){ ## fix missing values for variational 
     values[["iter"]] <- as.integer(values[["output_samples"]])
     values[["warmup"]] <- 0L
     values[["thin"]] <- 1L
@@ -187,7 +187,7 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
 
     close(con)
     cs_lst2[[i]] <- parse_stancsv_comments(comments)
-    if(cs_lst2[[1]]$method=="variational") 
+    if("output_samples" %in% names(cs_lst2[[i]])) 
       df <- df[-1,] # remove the means 
     ss_lst[[i]] <- df
   } 

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -114,7 +114,12 @@ parse_stancsv_comments <- function(comments) {
   for (z in names1) values[[z]] <- as.integer(values[[z]])
   for (z in names2) values[[z]] <- as.numeric(values[[z]])
   if (compute_iter) values[["iter"]] <- values[["iter"]] + values[["warmup"]]
-  if ("output_samples" %in% names(values)) values[["iter"]] <- as.integer(values[["output_samples"]])
+  if (values$method == "variational"){ ## fix missing values for variational 
+    values[["iter"]] <- as.integer(values[["output_samples"]])
+    values[["warmup"]] <- 0L
+    values[["thin"]] <- 1L
+    values[["save_warmup"]] <- 1L
+  }
   c(values, add_lst)  
 }
 
@@ -232,23 +237,14 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
       attr(samples[[i]], "elapsed_time") <- get_time_from_csv(cs_lst2[[i]]$time_info)
   } 
 
-  if(cs_lst2[[1]]$method=="variational"){
-    warmup <- rep(0L, length(i))
-    thin <- rep(1L, length(i))
-    save_warmup <- rep(0L, length(i))
-    
-  } else {
-    save_warmup <- sapply(cs_lst2, function(i) i$save_warmup)
-    
-    warmup <- sapply(cs_lst2, function(i) i$warmup)
-    thin <- sapply(cs_lst2, function(i) i$thin)
-  }
+  save_warmup <- sapply(cs_lst2, function(i) i$save_warmup)
+  warmup <- sapply(cs_lst2, function(i) i$warmup)
+  thin <- sapply(cs_lst2, function(i) i$thin)
   iter <- sapply(cs_lst2, function(i) i$iter)
 
   if (!all_int_eq(warmup) || !all_int_eq(thin) || !all_int_eq(iter)) 
     stop("not all iter/warmups/thin are the same in all CSV files")
-
-
+  
 
   n_kept0 <- 1 + (iter - warmup - 1) %/% thin
   warmup2 <- 0
@@ -262,7 +258,7 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     warning("the number of iterations after warmup found (", n_kept, 
             ") does not match iter/warmup/thin from CSV comments (",
             paste(n_kept0, collapse = ','), ")")
-    
+
     if (n_kept < 0) {
       warmup <- warmup + n_kept
       n_kept <- 0
@@ -270,18 +266,13 @@ read_stan_csv <- function(csvfiles, col_major = TRUE) {
     }
     n_kept0 <- n_save
     iter <- n_save
-    
+
     for (i in 1:length(cs_lst2)) {
       cs_lst2[[i]]$warmup <- warmup
       cs_lst2[[i]]$iter <- iter
     }
   }
-  
-  
   idx_kept <- if (warmup2 == 0) 1:n_kept else -(1:warmup2)
-    
-
- 
   for (i in seq_along(samples)) {
     m <- vapply(samples[[i]], function(x) mean(x[idx_kept]), numeric(1))
     attr(samples[[i]], "mean_pars") <- m[-length(m)]


### PR DESCRIPTION
#### Summary:
There is currently an error in how `read_stan_csv` parses output from cmdstan using variational estimates. To see this:

Run cmdstan:
`examples/bernoulli/bernoulli variational data file=examples/bernoulli/bernoulli.data.R`

Then in R try to load `output.csv`

```
> mod <- read_stan_csv("output.csv")
Error in numeric(iter.count) : vector size cannot be NA
```

#### Intended Effect:

Made a few small changes so that `read_stan_csv` would parse variational outputs in a way that made it usable. This set warmup =0, thin =1, and save_warmup=1. 

#### How to Verify:

Rerun `read_stan_csv`

#### Side Effects:

There is a warning that is issued because the elapsed time is not in the cmdstan output. 

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
