### PR TITLE
fix to pass vi diagnostic info from stan-dev/stan#2618

### DIFF
--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -226,6 +226,13 @@ setMethod("vb", "stanmodel",
 
             vbres <- sampler$call_sampler(c(args, dotlist))
             samples <- read_one_stan_csv(attr(vbres, "args")$sample_file)
+            diagnostic_columns <- which(grepl('__',colnames(samples)))[-1]
+            if (length(diagnostic_columns)>0) {
+                diagnostics <- samples[-1,diagnostic_columns]
+                samples <- samples[,-diagnostic_columns]
+            } else {
+                diagnostics <- NULL
+            }
             pest <- rstan_relist(as.numeric(samples[1,-1]), skeleton[-length(skeleton)])
             means <- sapply(samples, mean)
             means <- as.matrix(c(means[-1], means[1]))
@@ -247,6 +254,7 @@ setMethod("vb", "stanmodel",
             n_flatnames <- length(fnames_oi)
             iter <- nrow(samples)
             sim <- list(samples = list(as.list(samples)),
+                        diagnostics = list(as.list(diagnostics)),
                         iter = iter, thin = 1L,
                         warmup = 0L,
                         chains = 1L,


### PR DESCRIPTION
#### Summary:

fixes `vb` method for `stanmodel` to work with stan-dev/stan#2618

Right now just moves all columns with `__` except `lp__` to diagnostics slot.

This will make rstan to work with old and new StanHeaders.

Later features using `log_p__` and `log_g__` can be added

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses: Aki Vehtari
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
