### PR TITLE
Make sure correct points are colored

### DIFF
--- a/rstan/rstan/R/pairs.R
+++ b/rstan/rstan/R/pairs.R
@@ -136,12 +136,18 @@ pairs.stanfit <-
       if(!is.null(panel)) lower.panel <- panel
       else lower.panel <- function(x,y, ...) {
         dots <- list(...)
-        dots$x <- x[!mark]
-        dots$y <- y[!mark]
-        if (is.null(mc$nrpoints) && !identical(condition, "divergent__")) {
-          dots$nrpoints <- Inf
-          dots$col <- ifelse(divergent__[!mark] == 1, "red", 
-                      ifelse(hit[!mark] == 1, "yellow", NA_character_))
+        x_tmp <- x[!mark]
+        y_tmp <- y[!mark]
+        div_tmp <- divergent__[!mark]
+        hit_tmp <- hit[!mark]
+        dots$x <- x_tmp
+        dots$y <- y_tmp
+        dots$nrpoints <- 0
+        dots$postPlotHook <- function() {
+          if (!identical(condition, "divergent__")) {
+            points(x_tmp[div_tmp==1], y_tmp[div_tmp == 1], col = "red", pch = ".")
+            points(x_tmp[hit_tmp == 1], y_tmp[hit_tmp == 1], col = "yellow", pch = ".")
+          }
         }
         dots$add <- TRUE
         do.call(smoothScatter, args = dots)
@@ -151,12 +157,18 @@ pairs.stanfit <-
       if(!is.null(panel)) upper.panel <- panel
       else upper.panel <- function(x,y, ...) {
         dots <- list(...)
-        dots$x <- x[mark]
-        dots$y <- y[mark]
-        if (is.null(mc$nrpoints) && !identical(condition, "divergent__")) {
-          dots$nrpoints <- Inf
-          dots$col <- ifelse(divergent__[mark] == 1, "red", 
-                      ifelse(hit[mark] == 1, "yellow", NA_character_))
+        x_tmp <- x[mark]
+        y_tmp <- y[mark]
+        div_tmp <- divergent__[mark]
+        hit_tmp <- hit[mark]
+        dots$x <- x_tmp
+        dots$y <- y_tmp
+        dots$nrpoints <- 0
+        dots$postPlotHook <- function() {
+          if (!identical(condition, "divergent__")) {
+            points(x_tmp[div_tmp==1], y_tmp[div_tmp == 1], col = "red", pch = ".")
+            points(x_tmp[hit_tmp == 1], y_tmp[hit_tmp == 1], col = "yellow", pch = ".")
+          }
         }
         dots$add <- TRUE
         do.call(smoothScatter, args = dots)


### PR DESCRIPTION
This attempts to fix the issue of `smoothScatter` not coloring the correct points indicating divergences (and max td) when using the `pairs.stanfit` method (issue #599). It sets `nrpoints` to 0 and uses a `postPlotHook` function as suggested by @bgoodri. @bgoodri I think this is now working correctly but it would be good if more people could try it and verify. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
