### PR TITLE
Set ggplot2 theme defaults in .onLoad() 

### DIFF
--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -28,6 +28,7 @@ NeedsCompilation: yes
 Imports:
     methods,
     stats4,
+    ggplot2 (>= 2.0.0),
     inline,
     gridExtra (>= 2.0.0),
     Rcpp (>= 0.12.0),
@@ -35,7 +36,6 @@ Imports:
     pkgbuild
 Depends:
     R (>= 3.4.0),
-    ggplot2 (>= 2.0.0),
     StanHeaders (>= 2.18.0)
 LinkingTo: Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),

--- a/rstan/rstan/R/SBC.R
+++ b/rstan/rstan/R/SBC.R
@@ -77,8 +77,8 @@ plot.SBC <- function(x, thin = 4, ...) {
   parameter <- as.factor(rep(colnames(u), each = nrow(u)))
   d <- data.frame(u = c(u), parameter)
   suppressWarnings(ggplot2::ggplot(d) + 
-    ggplot2::geom_histogram(aes(x = u), pad = TRUE, ...) + 
-    ggplot2::facet_wrap(parameter))
+    ggplot2::geom_histogram(ggplot2::aes(x = u), pad = TRUE, ...) + 
+    ggplot2::facet_wrap("parameter"))
 }
 
 print.SBC <- function(x, ...) {

--- a/rstan/rstan/R/stan_plot.R
+++ b/rstan/rstan/R/stan_plot.R
@@ -14,31 +14,34 @@ stan_trace <- function(object, pars, include = TRUE,
   .check_object(object, unconstrain)
   plot_data <- .make_plot_data(object, pars, include, inc_warmup, unconstrain)
   
-  thm <- .rstanvis_defaults$theme
-  clrs <- rep_len(.rstanvis_defaults$chain_colors, plot_data$nchains)
+  thm <- rstanvis_theme()
+  clrs <- rep_len(rstanvis_aes_ops("chain_colors"), plot_data$nchains)
   
-  base <- ggplot(plot_data$samp,
-                 aes_string(x = "iteration", y = "value", color = "chain"))
+  base <-
+    ggplot2::ggplot(
+      plot_data$samp,
+      ggplot2::aes_string(x = "iteration", y = "value", color = "chain")
+    )
   if (inc_warmup) base <- base +
-    annotate("rect", xmin = -Inf, xmax = plot_data$warmup,
-             ymin = -Inf, ymax = Inf, fill = .rstanvis_defaults$grays[2L])
+    ggplot2::annotate("rect", xmin = -Inf, xmax = plot_data$warmup,
+             ymin = -Inf, ymax = Inf, fill = rstanvis_aes_ops("grays")[2L])
   
   graph <-
     base +
-    geom_path(...) +
-    scale_color_manual(values = clrs) +
-    labs(x="",y="") +
+    ggplot2::geom_path(...) +
+    ggplot2::scale_color_manual(values = clrs) +
+    ggplot2::labs(x="",y="") +
     thm
   
   if (plot_data$nparams == 1)
-    graph <- graph + ylab(unique(plot_data$samp$parameter))
+    graph <- graph + ggplot2::ylab(unique(plot_data$samp$parameter))
   else
-    graph <- graph + facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
+    graph <- graph + ggplot2::facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
   
   if (!is.null(window)) {
     if (!is.numeric(window) || length(window) != 2)
       stop("'window' should be a numeric vector of length 2.")
-    graph <- graph + coord_cartesian(xlim = window)
+    graph <- graph + ggplot2::coord_cartesian(xlim = window)
   }
   graph
 }
@@ -49,7 +52,7 @@ stan_scat <- function(object, pars, unconstrain = FALSE, inc_warmup = FALSE,
                       nrow = NULL, ncol = NULL, ...) {
   
   .check_object(object, unconstrain)
-  thm <- .rstanvis_defaults$theme
+  thm <- rstanvis_theme()
   dots <- .add_aesthetics(list(...), c("fill", "pt_color", "pt_size", "alpha", "shape"))
   if (missing(pars) || length(pars) != 2L)
     stop("'pars' must contain exactly two parameter names", call. = FALSE)
@@ -75,13 +78,13 @@ stan_scat <- function(object, pars, unconstrain = FALSE, inc_warmup = FALSE,
 #   sel <- seq_len(nrow(df) / nchains)
 #   div <- df[div[sel], ]
 #   td <- df[hit_max_td[sel], ]
-  base <- ggplot(df, aes_string("x", "y"))
+  base <- ggplot2::ggplot(df, ggplot2::aes_string("x", "y"))
   graph <-
     base +
-    do.call(geom_point, dots) +
+    do.call(ggplot2::geom_point, dots) +
 #     geom_point(data = div, aes_string("x","y"), color = "red") +
 #     geom_point(data = td, aes_string("x","y"), color = "yellow") +
-    labs(x = pars[1], y = pars[2]) +
+    ggplot2::labs(x = pars[1], y = pars[2]) +
     thm
   
   graph
@@ -98,18 +101,18 @@ stan_hist <- function(object, pars, include = TRUE,
   .check_object(object, unconstrain)
   dots <- .add_aesthetics(list(...), c("fill", "color"))
   plot_data <- .make_plot_data(object, pars, include, inc_warmup, unconstrain)
-  thm <- .rstanvis_defaults$hist_theme
-  base <- ggplot(plot_data$samp, aes_string(x = "value", y = "..density.."))
+  thm <- rstanvis_hist_theme()
+  base <- ggplot2::ggplot(plot_data$samp, ggplot2::aes_string(x = "value", y = "..density.."))
   graph <-
     base +
-    do.call(geom_histogram, dots) + 
-    xlab("") +
+    do.call(ggplot2::geom_histogram, dots) + 
+    ggplot2::xlab("") +
     thm
   
   if (plot_data$nparams == 1)
-    graph + xlab(unique(plot_data$samp$parameter))
+    graph + ggplot2::xlab(unique(plot_data$samp$parameter))
   else
-    graph + facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
+    graph + ggplot2::facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
 }
 
 
@@ -124,28 +127,28 @@ stan_dens <- function(object, pars, include = TRUE,
   
   .check_object(object, unconstrain)
   plot_data <- .make_plot_data(object, pars, include, inc_warmup, unconstrain)
-  clrs <- rep_len(.rstanvis_defaults$chain_colors, plot_data$nchains)
-  thm <- .rstanvis_defaults$hist_theme
-  base <- ggplot(plot_data$samp, aes_string(x = "value")) + xlab("")
+  clrs <- rep_len(rstanvis_aes_ops("chain_colors"), plot_data$nchains)
+  thm <- rstanvis_hist_theme()
+  base <- ggplot2::ggplot(plot_data$samp, ggplot2::aes_string(x = "value")) + ggplot2::xlab("")
   if (!separate_chains) {
     dots <- .add_aesthetics(list(...), c("fill", "color"))
     graph <-
       base +
-      do.call(geom_density, dots) + 
+      do.call(ggplot2::geom_density, dots) + 
       thm
   } else {
     dots <- .add_aesthetics(list(...), c("color", "alpha"))
-    dots$mapping <- aes_string(fill = "chain")
+    dots$mapping <- ggplot2::aes_string(fill = "chain")
     graph <-
       base +
-      do.call(geom_density, dots) + 
-      scale_fill_manual(values = clrs) +
+      do.call(ggplot2::geom_density, dots) + 
+      ggplot2::scale_fill_manual(values = clrs) +
       thm
   }
   if (plot_data$nparams == 1)
-    graph + xlab(unique(plot_data$samp$parameter))
+    graph + ggplot2::xlab(unique(plot_data$samp$parameter))
   else
-    graph + facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
+    graph + ggplot2::facet_wrap(~parameter, nrow = nrow, ncol = ncol, scales = "free")
 }
 
 
@@ -160,8 +163,8 @@ stan_ac <- function(object, pars, include = TRUE,
                     lags = 25, partial = FALSE) {
   .check_object(object, unconstrain)
   plot_data <- .make_plot_data(object, pars, include, inc_warmup, unconstrain)
-  clrs <- rep_len(.rstanvis_defaults$chain_colors, plot_data$nchains)
-  thm <- .rstanvis_defaults$theme
+  clrs <- rep_len(rstanvis_aes_ops("chain_colors"), plot_data$nchains)
+  thm <- rstanvis_theme()
   dots <- .add_aesthetics(list(...), c("size", "color", "fill"))
 
   dat_args <- list(dat = plot_data$samp, lags = lags, partial = partial)
@@ -172,41 +175,41 @@ stan_ac <- function(object, pars, include = TRUE,
     dots$stat <- "summary"
     dots$fun.y <- "mean"
     y_lab <- paste("Avg.", if (partial) "partial", "autocorrelation")
-    ac_labs <- labs(x = "Lag", y = y_lab)
-    y_scale <- scale_y_continuous(breaks = seq(0, 1, 0.25))
-    base <- ggplot(ac_dat, aes_string(x = "lag", y = "ac"))
+    ac_labs <- ggplot2::labs(x = "Lag", y = y_lab)
+    y_scale <- ggplot2::scale_y_continuous(breaks = seq(0, 1, 0.25))
+    base <- ggplot2::ggplot(ac_dat, ggplot2::aes_string(x = "lag", y = "ac"))
     graph <- base +
-      do.call(geom_bar, dots) + 
+      do.call(ggplot2::geom_bar, dots) + 
       y_scale +
       ac_labs +
       thm
     
     if (plot_data$nparams == 1) {
-      y_lab <- ylab(paste0(y_lab, " (", pars,")"))
+      y_lab <- ggplot2::ylab(paste0(y_lab, " (", pars,")"))
       return(graph + y_lab)
     }
-    else return(graph + facet_wrap(~parameters, nrow = nrow, ncol = ncol,
+    else return(graph + ggplot2::facet_wrap(~parameters, nrow = nrow, ncol = ncol,
                                    scales = "free_x"))
   }
   dots$position <- "identity"
   dots$stat <- "identity"
-  ac_labs <- labs(x = "Lag", y = if (partial)
+  ac_labs <- ggplot2::labs(x = "Lag", y = if (partial)
     "Partial autocorrelation" else "Autocorrelation")
-  y_scale <- scale_y_continuous(breaks = seq(0, 1, 0.25),
+  y_scale <- ggplot2::scale_y_continuous(breaks = seq(0, 1, 0.25),
                                 labels = c("0","","0.5","",""))
   
-  base <- ggplot(ac_dat, aes_string(x = "lag", y = "ac"))
+  base <- ggplot2::ggplot(ac_dat, ggplot2::aes_string(x = "lag", y = "ac"))
   graph <- base +
-    do.call(geom_bar, dots) +
+    do.call(ggplot2::geom_bar, dots) +
     y_scale +
     ac_labs +
     thm
   
   if (plot_data$nparams == 1) {
-    graph <- graph + facet_wrap(~chains, nrow = nrow, ncol = ncol)
+    graph <- graph + ggplot2::facet_wrap(~chains, nrow = nrow, ncol = ncol)
     return(graph)
   } else { # nParams > 1
-    graph <- graph + facet_grid(parameters ~ chains, scales = "free_x")
+    graph <- graph + ggplot2::facet_grid(parameters ~ chains, scales = "free_x")
     return(graph)
   }
 }
@@ -219,16 +222,16 @@ stan_plot <- function(object, pars, include = TRUE, unconstrain = FALSE,
   
   inc_warmup <- FALSE
   .check_object(object, unconstrain)
-  thm <- .rstanvis_defaults$multiparam_theme
+  thm <- rstanvis_multiparam_theme()
   plot_data <- .make_plot_data(object, pars, include, inc_warmup, unconstrain)
   
   color_by_rhat <- FALSE # FIXME 
   dots <- list(...)
   defs <- list(point_est = "median", show_density = FALSE,
                show_outer_line = TRUE, ci_level = 0.8, outer_level = 0.95,
-               fill_color = .rstanvis_defaults[["fill"]], 
-               outline_color = .rstanvis_defaults[["color"]], 
-               est_color = .rstanvis_defaults[["color"]])
+               fill_color = rstanvis_aes_ops("fill"), 
+               outline_color = rstanvis_aes_ops("color"), 
+               est_color = rstanvis_aes_ops("color"))
   args <- names(defs)
   dotenv <- list()
   for (j in seq_along(args)) {
@@ -264,17 +267,25 @@ stan_plot <- function(object, pars, include = TRUE, unconstrain = FALSE,
   colnames(xy.df) <- c("params", "y", "mean", "ll", "l", "m", "h", "hh")
   if (dotenv[["point_est"]] == "mean") xy.df$m <- xy.df$mean
   
-  p.base <- ggplot(xy.df)
-  p.name <- scale_y_continuous(breaks = y, labels = param_names,
+  p.base <- ggplot2::ggplot(xy.df)
+  p.name <- ggplot2::scale_y_continuous(breaks = y, labels = param_names,
                                limits = c(0.5, nparams + 1))
-  p.all <- p.base + xlim(xlim.use) + p.name + thm
+  p.all <- p.base + ggplot2::xlim(xlim.use) + p.name + thm
   show_density <- dotenv[["show_density"]]
-  outline_color <- dotenv[["outline_color"]] %ifNULL% .rstanvis_defaults[["color"]]
+  outline_color <- dotenv[["outline_color"]] %ifNULL% rstanvis_aes_ops("color")
   fill_color <- dotenv[["fill_color"]]
   est_color <- dotenv[["est_color"]]
   if (dotenv[["show_outer_line"]] || show_density) {
-    p.ci <- geom_segment(aes_string(x = "ll", xend = "hh", y = "y", yend = "y"),
-                         color = outline_color)
+    p.ci <-
+      ggplot2::geom_segment(
+        mapping = ggplot2::aes_string(
+          x = "ll",
+          xend = "hh",
+          y = "y",
+          yend = "y"
+        ),
+        color = outline_color
+      )
     p.all <- p.all + p.ci
   }
   if (show_density) { # plot kernel density estimate
@@ -291,8 +302,12 @@ stan_plot <- function(object, pars, include = TRUE, unconstrain = FALSE,
     }
     df.den <- data.frame(x = as.vector(x.den), y = as.vector(y.den),
                          name = rep(param_names, each = npoint.den))
-    p.den <- geom_line(data = df.den, aes_string("x", "y", group = "name"),
-                       color = outline_color)
+    p.den <-
+      ggplot2::geom_line(
+        data = df.den,
+        mapping = ggplot2::aes_string("x", "y", group = "name"),
+        color = outline_color
+      )
     
     #shaded interval
     y.poly <- x.poly <- matrix(0, nrow = npoint.den + 2, ncol = nparams)
@@ -307,29 +322,29 @@ stan_plot <- function(object, pars, include = TRUE, unconstrain = FALSE,
     }
     df.poly <- data.frame(x = as.vector(x.poly), y = as.vector(y.poly),
                           name = rep(param_names, each = npoint.den + 2))
-    p.poly <- geom_polygon(data = df.poly, aes_string("x", "y", group = "name", fill = "y"))
-    p.col <- scale_fill_gradient(low = fill_color, high = fill_color, guide = "none")
+    p.poly <- ggplot2::geom_polygon(data = df.poly, mapping=ggplot2::aes_string("x", "y", group = "name", fill = "y"))
+    p.col <- ggplot2::scale_fill_gradient(low = fill_color, high = fill_color, guide = "none")
     
     #point estimate
     if (color_by_rhat) {
       rhat_colors <- dotenv[["rhat_colors"]]
-      p.point <- geom_segment(aes_string(x = "m", xend = "m", y = "y", yend = "y + 0.25",
+      p.point <- ggplot2::geom_segment(ggplot2::aes_string(x = "m", xend = "m", y = "y", yend = "y + 0.25",
                                          color = "rhat_id"), size = 1.5)
       p.all + p.poly + p.den + p.col + p.point + rhat_colors #+ rhat_lgnd
     } else {
-      p.point <- geom_segment(aes_string(x = "m", xend = "m", y = "y", yend = "y + 0.25"),
+      p.point <- ggplot2::geom_segment(ggplot2::aes_string(x = "m", xend = "m", y = "y", yend = "y + 0.25"),
                               colour = est_color, size = 1.5)
       p.all + p.poly + p.den + p.col + p.point
     }
   } else {
-    p.ci.2 <- geom_segment(aes_string(x = "l", xend = "h", y = "y", yend = "y"),
+    p.ci.2 <- ggplot2::geom_segment(ggplot2::aes_string(x = "l", xend = "h", y = "y", yend = "y"),
                            colour = fill_color, size = 2)
     if (color_by_rhat) {
-      p.point <- geom_point(aes_string(x = "m", y = "y", fill = "rhat_id"),
+      p.point <- ggplot2::geom_point(ggplot2::aes_string(x = "m", y = "y", fill = "rhat_id"),
                             color = "black", shape = 21, size = 4)
       p.all + p.ci.2 + p.point + rhat_colors # + rhat_lgnd
     } else {
-      p.point <- geom_point(aes_string(x = "m", y = "y"), size = 4,
+      p.point <- ggplot2::geom_point(ggplot2::aes_string(x = "m", y = "y"), size = 4,
                             color = fill_color, fill = est_color, shape = 21)
       p.all + p.ci.2 + p.point
     }
@@ -380,7 +395,7 @@ stan_diag <- function(object,
 
 stan_stepsize <- function(object, chain = 0, ...) {
   .nuts_args_check(...)
-  thm <- .rstanvis_defaults$theme
+  thm <- rstanvis_theme()
   stepsize <- .sampler_params_post_warmup(object, "stepsize__", as.df = TRUE)
   lp <- extract(if (is.stanreg(object)) object$stanfit else object,
                        pars = "lp__", permuted = FALSE)[,,1L]
@@ -403,8 +418,8 @@ stan_stepsize <- function(object, chain = 0, ...) {
 
 stan_sample <- function(object, chain = 0, ...) {
   .nuts_args_check(...)
-  thm <- .rstanvis_defaults$theme
-  hist_thm <- .rstanvis_defaults$hist_theme
+  thm <- rstanvis_theme()
+  hist_thm <- rstanvis_hist_theme()
   lp <- extract(if (is.stanreg(object)) object$stanfit else object,
                        pars = "lp__", permuted = FALSE)[,,1L]
   lp_df <- as.data.frame(cbind(iterations = 1:nrow(lp), lp))
@@ -426,8 +441,8 @@ stan_sample <- function(object, chain = 0, ...) {
 
 stan_treedepth <- function(object, chain = 0, ...) {
   .nuts_args_check(...)
-  thm <- .rstanvis_defaults$theme
-  hist_thm <- .rstanvis_defaults$hist_theme
+  thm <- rstanvis_theme()
+  hist_thm <- rstanvis_hist_theme()
   lp <- extract(if (is.stanreg(object)) object$stanfit else object,
                        pars = "lp__", permuted = FALSE)[,,1L]
   treedepth <- .sampler_params_post_warmup(object, "treedepth__", as.df = TRUE)
@@ -469,7 +484,7 @@ stan_treedepth <- function(object, chain = 0, ...) {
 
 stan_divergence <- function(object, chain = 0, ...) {
   .nuts_args_check(...)
-  thm <- .rstanvis_defaults$theme
+  thm <- rstanvis_theme()
   lp <- extract(if (is.stanreg(object)) object$stanfit else object,
                        pars = "lp__", permuted = FALSE)[,,1L]
   ndivergent <- .sampler_params_post_warmup(object, "divergent__", as.df = TRUE)
@@ -497,7 +512,7 @@ stan_par <- function(object, par, chain = 0, ...) {
     object <- object$stanfit
   if (!isTRUE(ncol(object) > 1))
     stop("'stan_par' requires more than one chain.", call. = FALSE)
-  thm <- .rstanvis_defaults$theme
+  thm <- rstanvis_theme()
   samp <- extract(object, pars = c("lp__", par), permuted = FALSE)
   par_sel <- which(dimnames(samp)$parameters == par)
   

--- a/rstan/rstan/R/stan_plot_helpers.R
+++ b/rstan/rstan/R/stan_plot_helpers.R
@@ -5,7 +5,7 @@
   add_names <- gsub("pt_", "", to_add)
   for (j in seq_along(to_add)) {
     if (!add_names[j] %in% names(dots)) 
-      dots[[add_names[j]]] <- .rstanvis_defaults[[to_add[j]]]
+      dots[[add_names[j]]] <- rstanvis_aes_ops(to_add[j])
   }
   dots
 }
@@ -130,7 +130,7 @@ is.stanfit <- function(x) inherits(x, "stanfit")
   } else {
     window <- c(1, sim$iter[1])
   }
-  if ((all(sim$warmup2 == 0) || !inc_warmup) && window[1] <= sim$warmup[1]) {
+  if ((sim$warmup2 == 0 || !inc_warmup) && window[1] <= sim$warmup[1]) {
     window[1] <- sim$warmup[1] + 1
   }
   if (window[1] > window[2]) {
@@ -315,7 +315,7 @@ color_vector_chain <- function(n) {
 .rhat_neff_mcse_hist <- function(which = c("rhat", "n_eff_ratio", "mcse_ratio"),
                                  object, pars=NULL, ...) {
   if (is.stanreg(object)) object <- object$stanfit
-  thm <- .rstanvis_defaults$hist_theme
+  thm <- rstanvis_hist_theme()
   dots <- .add_aesthetics(list(...), c("fill", "color"))
   if (which == "n_eff_ratio") {
     lp <- suppressWarnings(get_logposterior(object, inc_warmup = FALSE))
@@ -335,10 +335,10 @@ color_vector_chain <- function(n) {
                  mcse_ratio = smry[, "se_mean"] / smry[, "sd"]
   )
   df <- data.frame(stat)
-  plot_labs <- labs(y = "", x = xlab)
-  base <- ggplot(df, aes(x = stat))
+  plot_labs <- ggplot2::labs(y = "", x = xlab)
+  base <- ggplot2::ggplot(df, ggplot2::aes(x = stat))
   base +
-    do.call(geom_histogram, dots) + 
+    do.call(ggplot2::geom_histogram, dots) + 
     plot_labs +
     thm
 }
@@ -436,30 +436,44 @@ color_vector_chain <- function(n) {
   dots$alpha <- 0.5 * dots$alpha
   dots$color <- .NUTS_PT_CLR
   dots$fill <- .NUTS_FILL
-  xy_labs <- labs(y = if (missing(p_lab)) NULL else p_lab,
-                  x = if (missing(sp_lab)) NULL else sp_lab)
+  xy_labs <- ggplot2::labs(
+    y = if (missing(p_lab)) NULL else p_lab,
+    x = if (missing(sp_lab)) NULL else sp_lab
+  )
   df <- data.frame(sp = do.call("c", sp), p = c(p))
   if (violin) df$sp <- as.factor(round(df$sp, 4))
   if (!is.null(divergent)) df$divergent <- do.call("c", divergent)
   if (!is.null(hit_max_td)) df$hit_max_td <- do.call("c", hit_max_td)
   
-  base <- ggplot(df, aes_string(x = "sp", y = "p")) + xy_labs
+  base <- ggplot2::ggplot(df, ggplot2::aes_string(x = "sp", y = "p")) + xy_labs
   if (chain == 0) {
     if (violin)
-      graph <- base + geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL)
+      graph <- base + ggplot2::geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL)
     else {
-      graph <- base + do.call(geom_point, dots)
-      if (smoother) graph <- graph + stat_smooth(se = FALSE)
+      graph <- base + do.call(ggplot2::geom_point, dots)
+      if (smoother) graph <- graph + ggplot2::stat_smooth(se = FALSE)
       if (!is.null(divergent))
-        graph <- graph + geom_point(data = subset(df, divergent == 1),
-                                    aes_string(x = "sp", y = "p"),
-                                    color = .NDIVERGENT_CLR, fill = .NDIVERGENT_FILL,
-                                    alpha = 0.8, size = 3, shape = .DIV_AND_MAXTD_SHAPE)
+        graph <-
+          graph + ggplot2::geom_point(
+            data = subset(df, divergent == 1),
+            mapping = ggplot2::aes_string(x = "sp", y = "p"),
+            color = .NDIVERGENT_CLR,
+            fill = .NDIVERGENT_FILL,
+            alpha = 0.8,
+            size = 3,
+            shape = .DIV_AND_MAXTD_SHAPE
+          )
       if (!is.null(hit_max_td))
-        graph <- graph + geom_point(data = subset(df, hit_max_td == 1),
-                                    aes_string(x = "sp", y = "p"),
-                                    color = .MAXTD_CLR, fill = .MAXTD_FILL,
-                                    alpha = 0.8, size = 3, shape = .DIV_AND_MAXTD_SHAPE)
+        graph <-
+          graph + ggplot2::geom_point(
+            data = subset(df, hit_max_td == 1),
+            mapping = ggplot2::aes_string(x = "sp", y = "p"),
+            color = .MAXTD_CLR,
+            fill = .MAXTD_FILL,
+            alpha = 0.8,
+            size = 3,
+            shape = .DIV_AND_MAXTD_SHAPE
+          )
     }
     return(graph)
   }
@@ -471,47 +485,75 @@ color_vector_chain <- function(n) {
   if (violin) {
     chain_data$sp <- as.factor(round(chain_data$sp, 4))
     graph <- base +
-      geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL, ...) +
-      geom_violin(data = chain_data, aes_string(x = "sp", y = "p"),
-                  color = chain_clr, fill = chain_fill, ...)
+      ggplot2::geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL, ...) +
+      ggplot2::geom_violin(
+        data = chain_data,
+        mapping = ggplot2::aes_string(x = "sp", y = "p"),
+        color = chain_clr,
+        fill = chain_fill,
+        ...
+      )
     return(graph)
   }
-  graph <- base + do.call(geom_point, dots)
-  if (smoother) graph <- graph + stat_smooth(se = FALSE)
+  graph <- base + do.call(ggplot2::geom_point, dots)
+  if (smoother) graph <- graph + ggplot2::stat_smooth(se = FALSE)
   graph <- graph +
-    geom_point(data = chain_data, aes_string(x = "sp", y = "p"),
-               color = chain_fill, ...)
+    ggplot2::geom_point(
+      data = chain_data,
+      mapping = ggplot2::aes_string(x = "sp", y = "p"),
+      color = chain_fill,
+      ...
+    )
   if (smoother) graph <- graph +
-    stat_smooth(data = chain_data, aes_string(x = "sp", y = "p"),
-                color = chain_fill, se = FALSE)
+    ggplot2::stat_smooth(
+      data = chain_data,
+      mapping = ggplot2::aes_string(x = "sp", y = "p"),
+      color = chain_fill,
+      se = FALSE
+    )
   if (!is.null(divergent))
-    graph <- graph + geom_point(data = chain_data[chain_data$div == 1,, drop=FALSE],
-                                aes_string(x = "sp", y = "p"),
-                                color = .NDIVERGENT_CLR, fill = .NDIVERGENT_FILL,
-                                size = 3, shape = .DIV_AND_MAXTD_SHAPE)
+    graph <- graph + 
+     ggplot2::geom_point(
+      data = chain_data[chain_data$div == 1, , drop = FALSE],
+      mapping = ggplot2::aes_string(x = "sp", y = "p"),
+      color = .NDIVERGENT_CLR,
+      fill = .NDIVERGENT_FILL,
+      size = 3,
+      shape = .DIV_AND_MAXTD_SHAPE
+     )
   if (!is.null(hit_max_td))
-    graph <- graph + geom_point(data = chain_data[chain_data$hit == 1,, drop=FALSE],
-                                aes_string(x = "sp", y = "p"),
-                                color = .MAXTD_CLR, fill = .MAXTD_FILL,
-                                size = 3, shape = .DIV_AND_MAXTD_SHAPE)
+    graph <-
+    graph + ggplot2::geom_point(
+      data = chain_data[chain_data$hit == 1, , drop = FALSE],
+      mapping = ggplot2::aes_string(x = "sp", y = "p"),
+      color = .MAXTD_CLR,
+      fill = .MAXTD_FILL,
+      size = 3,
+      shape = .DIV_AND_MAXTD_SHAPE
+    )
   graph
 }
 
 .sampler_param_vs_sampler_param_violin <- function(df_x, df_y, lab_x, lab_y,
                                                    chain = 0) {
   
-  xy_labs <- labs(y = lab_y, x = lab_x)
+  xy_labs <- ggplot2::labs(y = lab_y, x = lab_x)
   df <- data.frame(x = do.call("c", df_x), y = do.call("c", df_y))
   df$x <- as.factor(df$x)
   
-  base <- ggplot(df, aes_string("x","y")) + xy_labs
-  graph <- base + geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL)
+  base <- ggplot2::ggplot(df, ggplot2::aes_string("x","y")) + xy_labs
+  graph <- base + ggplot2::geom_violin(color = .NUTS_CLR, fill = .NUTS_FILL)
   if (chain == 0) return(graph)
   chain_clr <- color_vector_chain(ncol(df_x))[chain]
   chain_fill <- chain_clr
   chain_data <- data.frame(x = as.factor(df_x[, chain]), y = df_y[, chain])
-  graph + geom_violin(data = chain_data, aes_string("x","y"), color = chain_clr,
-                      fill = chain_fill, alpha = 0.5)
+  graph + ggplot2::geom_violin(
+    data = chain_data,
+    mapping = ggplot2::aes_string("x", "y"),
+    color = chain_clr,
+    fill = chain_fill,
+    alpha = 0.5
+  )
 }
 
 .p_hist <- function(df, lab, chain = 0, ...) {
@@ -520,23 +562,23 @@ color_vector_chain <- function(n) {
   dots$binwidth <- diff(range(mdf$value))/30
   dots$fill <- .NUTS_FILL
   dots$color <- .NUTS_CLR
-  base <- ggplot(mdf, aes_string(x = "value")) +
-    do.call(geom_histogram, dots) + 
-    labs(x = if (missing(lab)) NULL else lab, y = "")
+  base <- ggplot2::ggplot(mdf, ggplot2::aes_string(x = "value")) +
+    do.call(ggplot2::geom_histogram, dots) + 
+    ggplot2::labs(x = if (missing(lab)) NULL else lab, y = "")
   if (chain == 0) {
     graph <- base +
-      geom_vline(xintercept = mean(mdf$value), color = .NUTS_VLINE_CLR, size = .8) +
-      geom_vline(xintercept = median(mdf$value), color = .NUTS_VLINE_CLR, lty = 2, size = 1)
+      ggplot2::geom_vline(xintercept = mean(mdf$value), color = .NUTS_VLINE_CLR, size = .8) +
+      ggplot2::geom_vline(xintercept = median(mdf$value), color = .NUTS_VLINE_CLR, lty = 2, size = 1)
     return(graph)
   }
   chain_data <- mdf[mdf$variable == paste0("chain:",chain), ]
   chain_clr <- color_vector_chain(ncol(df) - 1)[chain]
   chain_fill <- chain_clr
-  base + geom_histogram(data = chain_data,
+  base + ggplot2::geom_histogram(data = chain_data,
                         binwidth = diff(range(chain_data$value))/30,
                         fill = chain_fill, alpha = 0.5) +
-    geom_vline(xintercept = mean(chain_data$value), color = chain_clr, size = .8) +
-    geom_vline(xintercept = median(chain_data$value),
+    ggplot2::geom_vline(xintercept = mean(chain_data$value), color = chain_clr, size = .8) +
+    ggplot2::geom_vline(xintercept = median(chain_data$value),
                color = chain_clr, lty = 2, size = 1)
 }
 
@@ -544,7 +586,7 @@ color_vector_chain <- function(n) {
                                        divergent = c("All", 0, 1), ...) {
   x_lab <- if (divergent == "All")
     "Treedepth" else paste0("Treedepth (Divergent = ", divergent,")")
-  plot_labs <- labs(x = x_lab, y = "")
+  plot_labs <- ggplot2::labs(x = x_lab, y = "")
   
   mdf_td <- .reshape_df(df_td) #reshape2::melt(df_td, id.vars = grep("iteration", colnames(df_td), value = TRUE))
   mdf_nd <- .reshape_df(df_nd) #reshape2::melt(df_nd, id.vars = grep("iteration", colnames(df_nd), value = TRUE))
@@ -552,15 +594,14 @@ color_vector_chain <- function(n) {
   plot_data <- if (divergent == "All") mdf else mdf[mdf$div == divergent,,drop=FALSE]
   if (nrow(plot_data) == 0) return(NULL)
   
-  graph <- ggplot(plot_data, aes_q(x = quote(factor(value))), na.rm = TRUE) +
-    geom_bar(aes_q(y=quote(..count../sum(..count..))),
-             width=1, fill = .NUTS_FILL, color = .NUTS_CLR) +
-    plot_labs
+  graph <- ggplot2::ggplot(plot_data, ggplot2::aes_q(x = quote(factor(value))), na.rm = TRUE) +
+    ggplot2::geom_bar(mapping = ggplot2::aes_q(y=quote(..count../sum(..count..))),
+             width=1, fill = .NUTS_FILL, color = .NUTS_CLR) + plot_labs
   if (chain == 0) return(graph)
   chain_clr <- color_vector_chain(ncol(df_td) - 1)[chain]
   chain_fill <- chain_clr
   chain_data <- plot_data[plot_data$variable == paste0("chain:",chain),, drop=FALSE]
-  graph + geom_bar(data = chain_data, aes_q(y=quote(..count../sum(..count..))),
+  graph + ggplot2::geom_bar(data = chain_data, mapping = ggplot2::aes_q(y=quote(..count../sum(..count..))),
                    fill = chain_fill, width = 1)
 }
 

--- a/rstan/rstan/R/stan_plot_options.R
+++ b/rstan/rstan/R/stan_plot_options.R
@@ -29,56 +29,84 @@ rstan_ggtheme_options <- function(...) {
 
 
 
-# defaults ----------------------------------------------------------------
-.rstanvis_defaults <- new.env(parent = emptyenv())
-.rstanvis_defaults$theme <-
-  theme_classic(base_size = 11) +
-  theme(axis.line = element_line(color = "#222222"),
-        axis.line.y = element_line(size = .5),
-        axis.line.x = element_line(size = 1),
-        axis.title = element_text(face = "bold", size = 13),
-        strip.background = element_blank(),
-        strip.text = element_text(color = "black", face = "bold"),
-        legend.title = element_text(size = 11),
-        plot.title = element_text(size = 18))
+# internal ----------------------------------------------------------------
 
-for (j in seq_along(.rstanvis_defaults$theme)) {
-  if ("element_text" %in% class(.rstanvis_defaults$theme[[j]])) {
-    .rstanvis_defaults$theme[[j]][["debug"]] <- FALSE
-  }
+.rstanvis_defaults <- new.env(parent = emptyenv())
+
+rstanvis_theme <- function() .rstanvis_defaults$theme
+rstanvis_hist_theme <- function() .rstanvis_defaults$hist_theme
+rstanvis_multiparam_theme <- function() .rstanvis_defaults$multiparam_theme
+rstanvis_aes_ops <- function(nm = NULL) {
+  if (is.null(nm)) return(.rstanvis_defaults$aes_ops)
+  else return(.rstanvis_defaults$aes_ops[[nm]])
 }
 
-.rstanvis_defaults$hist_theme <-
-  .rstanvis_defaults$theme +
-  theme(axis.ticks.y = element_blank(),
-        axis.text.y = element_blank(),
-        axis.title.y = element_blank(),
-        axis.line.y = element_blank())
-
-.rstanvis_defaults$multiparam_theme <-
-  .rstanvis_defaults$theme +
-  theme(axis.title = element_blank(),
-        axis.text.y = element_text(face = "bold", size = 13, debug = FALSE),
-        legend.position = "none",
-        panel.grid.major =  element_line(size = 0.1, color = "darkgray"))
-
-.rstanvis_defaults$pt_color <- "#B2001D"
-.rstanvis_defaults$alpha <- 0.5
-.rstanvis_defaults$shape <- 19
-.rstanvis_defaults$fill <-  "#B2001D"
-.rstanvis_defaults$color <- "black" #"#590815"
-.rstanvis_defaults$size <- 0.5
-.rstanvis_defaults$pt_size <- 3
-
-.rstanvis_defaults$chain_colors <- rgb(matrix(c(230, 97, 1,
-                                                153, 142, 195,
-                                                84, 39, 136,
-                                                241, 163, 64,
-                                                216, 218, 235,
-                                                254, 224, 182),
-                                              byrow = TRUE, ncol = 3),
-                                       names = paste(1:6), maxColorValue = 255)
-.rstanvis_defaults$grays <- rgb(matrix(c(247, 247, 247, 204, 204, 204,
-                                         150, 150, 150, 82, 82, 82),
-                                       byrow = TRUE, ncol = 3),
-                                alpha = 100, names = paste(1:4), maxColorValue = 255)
+# called in .onLoad()
+set_rstan_ggplot_defaults <- function() {
+  .rstanvis_defaults$theme <- ggplot2::theme_classic(base_size = 11) +
+    ggplot2::theme(axis.line = ggplot2::element_line(color = "#222222"),
+          axis.line.y = ggplot2::element_line(size = .5),
+          axis.line.x = ggplot2::element_line(size = 1),
+          axis.title = ggplot2::element_text(face = "bold", size = 13),
+          strip.background = ggplot2::element_blank(),
+          strip.text = ggplot2::element_text(color = "black", face = "bold"),
+          legend.title = ggplot2::element_text(size = 11),
+          plot.title = ggplot2::element_text(size = 18))
+  
+  for (j in seq_along(.rstanvis_defaults$theme)) {
+    if ("element_text" %in% class(.rstanvis_defaults$theme[[j]])) {
+      .rstanvis_defaults$theme[[j]][["debug"]] <- FALSE
+    }
+  }
+  
+  .rstanvis_defaults$hist_theme <-
+    .rstanvis_defaults$theme +
+    ggplot2::theme(axis.ticks.y = ggplot2::element_blank(),
+          axis.text.y = ggplot2::element_blank(),
+          axis.title.y = ggplot2::element_blank(),
+          axis.line.y = ggplot2::element_blank())
+  
+  .rstanvis_defaults$multiparam_theme <-
+    .rstanvis_defaults$theme +
+    theme(axis.title = ggplot2::element_blank(),
+          axis.text.y = ggplot2::element_text(face = "bold", size = 13, debug = FALSE),
+          legend.position = "none",
+          panel.grid.major =  ggplot2::element_line(size = 0.1, color = "darkgray"))
+  
+  .rstanvis_defaults$aes_ops <- list()
+  .rstanvis_defaults$aes_ops$pt_color <- "#B2001D"
+  .rstanvis_defaults$aes_ops$alpha <- 0.5
+  .rstanvis_defaults$aes_ops$shape <- 19
+  .rstanvis_defaults$aes_ops$fill <-  "#B2001D"
+  .rstanvis_defaults$aes_ops$color <- "black" #"#590815"
+  .rstanvis_defaults$aes_ops$size <- 0.5
+  .rstanvis_defaults$aes_ops$pt_size <- 3
+  .rstanvis_defaults$aes_ops$chain_colors <- 
+    rgb(
+      matrix(
+        c(230, 97, 1,
+          153, 142, 195,
+          84, 39, 136,
+          241, 163, 64,
+          216, 218, 235,
+          254, 224, 182),
+        byrow = TRUE, 
+        ncol = 3
+      ),
+      names = paste(1:6), 
+      maxColorValue = 255
+    )
+  
+  .rstanvis_defaults$aes_ops$grays <-
+    rgb(
+      matrix(
+        c(247, 247, 247, 204, 204, 204,
+          150, 150, 150, 82, 82, 82),
+        byrow = TRUE,
+        ncol = 3
+      ),
+      alpha = 100,
+      names = paste(1:4),
+      maxColorValue = 255
+    )
+}

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -21,6 +21,7 @@ OUT <- quote(warning("'OUT' no longer does anything useful; see help(expose_stan
 
 .onLoad <- function(libname, pkgname) {
   assignInMyNamespace("rstan_load_time", value = Sys.time())  
+  set_rstan_ggplot_defaults()
 }
 
 .onAttach <- function(...) {


### PR DESCRIPTION
This PR fixes #631 by setting the ggplot2 default theme settings in `.onLoad()`. There are no user-facing changes. 

@bgoodri I've also moved ggplot2 from Depends to Imports, which I think should be ok now. 
I also added `ggplot2::` namespace prefixes when calling functions from ggplot2, which isn't strictly necessary with import("ggplot2") in the NAMESPACE file, but I like being able to quickly identify the ggplot2 functions we are using.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
