### PR TITLE
pass 'data' to parse_data() (fixes bug if data is named "i")

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1590,7 +1590,7 @@ get_time_from_csv <- function(tlines) {
   t
 }
 
-parse_data <- function(cppcode, data = NULL) {
+parse_data <- function(cppcode) {
   cppcode <- scan(what = character(), sep = "\n", quiet = TRUE,
                   text = cppcode)
   private <- grep("^private:$", cppcode) + 1L
@@ -1602,17 +1602,10 @@ parse_data <- function(cppcode, data = NULL) {
   in_data <- grep("context__.vals_", cppcode, fixed = TRUE, value = TRUE)
   in_data <- gsub('^.*\\("(.*)\"\\).*;$', "\\1", in_data)  
   
+  # get them from the calling environment
   objects <- intersect(objects, in_data)
-  if (is.null(data)) {
-    # get them from the calling environment
-    stuff <- sapply(objects, simplify = FALSE, FUN = dynGet, 
-                    inherits = FALSE, ifnotfound = NULL) 
-  } else {
-    # get them from 'data', and we know already from sampling() and other
-    # methods that is.list(data) & !is.data.frame(data)
-    stuff <- mget(objects, envir = as.environment(data), inherits = FALSE,
-                  ifnotfound = rep(list(NULL), length(objects)))
-  }
+  stuff <- sapply(objects, simplify = FALSE, FUN = dynGet, 
+                  inherits = FALSE, ifnotfound = NULL)
   for (i in seq_along(stuff)) if (is.null(stuff[[i]])) {
     if (exists(objects[i], envir = globalenv(), mode = "numeric"))
       stuff[[i]] <- get(objects[i], envir = globalenv(), mode = "numeric")
@@ -1621,7 +1614,6 @@ parse_data <- function(cppcode, data = NULL) {
   }
   return(stuff)
 }
-
 
 set_cppo <- function(...) {
   warning("'set_cppo' is defunct; manually edit your Makevars file if necessary")

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1604,8 +1604,11 @@ parse_data <- function(cppcode) {
   
   # get them from the calling environment
   objects <- intersect(objects, in_data)
-  stuff <- sapply(objects, simplify = FALSE, FUN = dynGet, 
-                  inherits = FALSE, ifnotfound = NULL)
+  stuff <- list()
+  for (int in seq_along(objects)) {
+   stuff[[objects[int]]] <- dynGet(objects[int], inherits = FALSE, ifnotfound = NULL)
+  }
+  
   for (i in seq_along(stuff)) if (is.null(stuff[[i]])) {
     if (exists(objects[i], envir = globalenv(), mode = "numeric"))
       stuff[[i]] <- get(objects[i], envir = globalenv(), mode = "numeric")

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1590,7 +1590,7 @@ get_time_from_csv <- function(tlines) {
   t
 }
 
-parse_data <- function(cppcode) {
+parse_data <- function(cppcode, data = NULL) {
   cppcode <- scan(what = character(), sep = "\n", quiet = TRUE,
                   text = cppcode)
   private <- grep("^private:$", cppcode) + 1L
@@ -1602,10 +1602,17 @@ parse_data <- function(cppcode) {
   in_data <- grep("context__.vals_", cppcode, fixed = TRUE, value = TRUE)
   in_data <- gsub('^.*\\("(.*)\"\\).*;$', "\\1", in_data)  
   
-  # get them from the calling environment
   objects <- intersect(objects, in_data)
-  stuff <- sapply(objects, simplify = FALSE, FUN = dynGet, 
-                  inherits = FALSE, ifnotfound = NULL)
+  if (is.null(data)) {
+    # get them from the calling environment
+    stuff <- sapply(objects, simplify = FALSE, FUN = dynGet, 
+                    inherits = FALSE, ifnotfound = NULL) 
+  } else {
+    # get them from 'data', and we know already from sampling() and other
+    # methods that is.list(data) & !is.data.frame(data)
+    stuff <- mget(objects, envir = as.environment(data), inherits = FALSE,
+                  ifnotfound = rep(list(NULL), length(objects)))
+  }
   for (i in seq_along(stuff)) if (is.null(stuff[[i]])) {
     if (exists(objects[i], envir = globalenv(), mode = "numeric"))
       stuff[[i]] <- get(objects[i], envir = globalenv(), mode = "numeric")
@@ -1614,6 +1621,7 @@ parse_data <- function(cppcode) {
   }
   return(stuff)
 }
+
 
 set_cppo <- function(...) {
   warning("'set_cppo' is defunct; manually edit your Makevars file if necessary")

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -115,7 +115,7 @@ setMethod("vb", "stanmodel",
                    ...) {
             stan_fit_cpp_module <- object@mk_cppmodule(object)
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- parse_data(get_cppcode(object), data = data)
+              parsed_data <- with(data, parse_data(get_cppcode(object)))
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -349,7 +349,7 @@ setMethod("optimizing", "stanmodel",
             stan_fit_cpp_module <- object@mk_cppmodule(object)
 
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- parse_data(get_cppcode(object), data = data)
+              parsed_data <- with(data, parse_data(get_cppcode(object)))
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -503,7 +503,7 @@ setMethod("sampling", "stanmodel",
                               pre_msg = "passing deprecated arguments: ")
             objects <- ls()
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- parse_data(get_cppcode(object), data = data)
+              parsed_data <- with(data, parse_data(get_cppcode(object)))
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -856,7 +856,7 @@ setMethod("gqs", "stanmodel",
   draws <- as.matrix(draws)
   objects <- ls()
   if (is.list(data) & !is.data.frame(data)) {
-    parsed_data <- parse_data(get_cppcode(object), data = data)
+    parsed_data <- with(data, parse_data(get_cppcode(object)))
     if (!is.list(parsed_data)) {
       message("failed to get names of data from the model; sampling not done")
       return(invisible(new_empty_stanfit(object)))

--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -115,7 +115,7 @@ setMethod("vb", "stanmodel",
                    ...) {
             stan_fit_cpp_module <- object@mk_cppmodule(object)
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- with(data, parse_data(get_cppcode(object)))
+              parsed_data <- parse_data(get_cppcode(object), data = data)
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -349,7 +349,7 @@ setMethod("optimizing", "stanmodel",
             stan_fit_cpp_module <- object@mk_cppmodule(object)
 
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- with(data, parse_data(get_cppcode(object)))
+              parsed_data <- parse_data(get_cppcode(object), data = data)
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -503,7 +503,7 @@ setMethod("sampling", "stanmodel",
                               pre_msg = "passing deprecated arguments: ")
             objects <- ls()
             if (is.list(data) & !is.data.frame(data)) {
-              parsed_data <- with(data, parse_data(get_cppcode(object)))
+              parsed_data <- parse_data(get_cppcode(object), data = data)
               if (!is.list(parsed_data)) {
                 message("failed to get names of data from the model; sampling not done")
                 return(invisible(new_empty_stanfit(object)))
@@ -856,7 +856,7 @@ setMethod("gqs", "stanmodel",
   draws <- as.matrix(draws)
   objects <- ls()
   if (is.list(data) & !is.data.frame(data)) {
-    parsed_data <- with(data, parse_data(get_cppcode(object)))
+    parsed_data <- parse_data(get_cppcode(object), data = data)
     if (!is.list(parsed_data)) {
       message("failed to get names of data from the model; sampling not done")
       return(invisible(new_empty_stanfit(object)))


### PR DESCRIPTION
fixes #654

#### Summary:

Data named `i` was overwritten by RStan.

#### Intended Effect

Give `parse_data()` a data argument instead of using `with(data, ...)` in `sampling()`. And then use `mget()` instead of `dynGet()` inside of parse_data(). This avoid overwriting `i`, but it's unclear why it was being overwritten. See comments in #654. 


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
