### PR TITLE
avoid integer overflow for big N

### DIFF
--- a/rstan/rstan/R/monitor.R
+++ b/rstan/rstan/R/monitor.R
@@ -50,7 +50,7 @@ autocovariance <- function(y) {
   transform <- fft(yc)
   ac <- fft(Conj(transform) * transform, inverse = TRUE)
   # use "biased" estimate as recommended by Geyer (1992)
-  ac <- Re(ac)[1:N] / (N * N * 2)
+  ac <- Re(ac)[1:N] / (N^2 * 2)
   ac
 }
 


### PR DESCRIPTION
monitor.R autocovariance computation had `N * N` where `N` is integer, and the result can overflow to NA (e.g. with N<-50000L). Replaced with `N^2` which returns double.
