### PR TITLE
fix read_csv_header

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1511,6 +1511,7 @@ read_csv_header <- function(f, comment.char = '#') {
   iter.count <- NA
   save.warmup <- FALSE
   sample.count <- NA_integer_
+  thin <- NULL
   while (length(input <- readLines(con, n = 1)) > 0) {
     niter <- niter + 1
     if (!grepl(comment.char, input)) break;
@@ -1523,6 +1524,9 @@ read_csv_header <- function(f, comment.char = '#') {
       warmup.count <- as.integer(gsub("[^0-9]*([0-9]*).*","\\1",input))
     } else {
       warmup.count <- 0L
+    }
+    if (grepl("#.*thin", input)){
+      thin <- as.integer(gsub("[^0-9]*([0-9]*).*","\\1",input))
     }
     if (grepl("#.*save_warmup",input)){
       save.warmup <- !grepl("0",input)
@@ -1538,7 +1542,10 @@ read_csv_header <- function(f, comment.char = '#') {
       iter.count <- warmup.count + sample.count
     else
       iter.count <- sample.count
-  } 
+  }
+  if(!is.null(thin)){
+    iter.count <- iter.count %/% thin
+  }
   attr(header, "iter.count") <- iter.count
   attr(header, "lineno") <- niter
   close(con)


### PR DESCRIPTION
#691 Use read_stan_csv() with csv file from cmdstan with thin parameter give an error

#### Summary:
I fixed my issue #691 with this little modification in function `read_csv_header()`but I don't know if I'm right and if this has no side effects

```
files_thin <- c("output_thin4chain1.csv", "output_thin4chain2.csv")
stan_fit2 <- rstan::read_stan_csv(files_thin)
rstan::traceplot(stan_fit2, "theta")
```
![Rplot_3](https://user-images.githubusercontent.com/39067995/64078839-4098b100-cce0-11e9-92e2-95cd4b628d60.png)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)