### PR TITLE
Tighten up check on warmup vs iter

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -364,7 +364,7 @@ config_argss <- function(chains, iter, warmup, thin,
   if (thin < 1 || thin > iter)
     stop("parameter 'thin' should be a positive integer less than 'iter'")
   warmup <- max(0, as.integer(warmup))
-  if (warmup > iter)
+  if (warmup >= iter)
     stop("parameter 'warmup' should be an integer less than 'iter'")
   chains <- as.integer(chains)
   if (chains < 1)

--- a/rstan/rstan/man/stan.Rd
+++ b/rstan/rstan/man/stan.Rd
@@ -84,7 +84,7 @@ stan(file, model_name = "anon_model", model_code = "", fit = NA,
     iterations per chain. If step-size adaptation is on (which it is by default), 
     this also controls the number of iterations for which adaptation is run (and
     hence these warmup samples should not be used for inference). The number of 
-    warmup iterations should not be larger than \code{iter} and the default is 
+    warmup iterations should be smaller than \code{iter} and the default is
     \code{iter/2}.}
     
   \item{chains}{A positive integer specifying the number of Markov chains. 

--- a/rstan/rstan/man/stanmodel-method-sampling.Rd
+++ b/rstan/rstan/man/stanmodel-method-sampling.Rd
@@ -59,7 +59,7 @@
     iterations per chain. If step-size adaptation is on (which it is by default), 
     this also controls the number of iterations for which adaptation is run (and
     hence these warmup samples should not be used for inference). The number of 
-    warmup iterations should not be larger than \code{iter} and the default is 
+    warmup iterations should be smaller than \code{iter} and the default is
     \code{iter/2}.}
 
   \item{thin}{A positive integer specifying the period for saving samples. 


### PR DESCRIPTION
#### Summary:
Fixes #693.

#### Intended Effect:
The following error should occur if `warmup == iter`: 
```
Error in config_argss(chains = chains, iter = iter, warmup = warmup, thin = thin,  :
  parameter 'warmup' should be an integer less than 'iter'
```

#### Side Effects:
None.

#### Documentation:
Updated to reflect the change.

#### Reviewer Suggestions: 
@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
