### PR TITLE
Fix gqs(): get right column names for non-scalar parameters

### DIFF
--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -896,9 +896,13 @@ setMethod("gqs", "stanmodel",
   m_pars = sampler$param_names()
   p_dims = sampler$param_dims()
   p_names <- unique(sub("\\..*$", "", sampler$constrained_param_names(TRUE, FALSE)))
-  draws <- draws[ , p_names, drop = FALSE]
   all_names <- sampler$constrained_param_names(TRUE, TRUE)
   some_names <- sampler$constrained_param_names(TRUE, FALSE)
+  draws_colnames <- sub("\\.", "[", some_names)
+  draws_colnames <- gsub("\\.", ",", draws_colnames)
+  draws_colnames[grep("\\[", draws_colnames)] <- 
+    paste0(draws_colnames[grep("\\[", draws_colnames)], "]")
+  draws <- draws[, draws_colnames, drop = FALSE]
   gq_names <- unique(sub("\\..*$", "", setdiff(all_names, some_names)))
   sampler$update_param_oi(gq_names)
   samples <- try(sampler$standalone_gqs(draws, as.integer(seed)))


### PR DESCRIPTION
This fixes #695, with the help of @mki71.

#### To verify

This should now run without an error:

```r
mc1 <- "
parameters {real xx[2,2,2]; real yy;} 
model {for (i in 1:2) to_vector(to_matrix(xx[i])) ~ normal(0, 1); yy ~ normal(0, 1);}
"
m1 <- stan_model(model_code = mc1)
f1 <- sampling(m1, iter = 300)

mc2 <- "
parameters {real xx[2,2,2]; real yy;} 
generated quantities {real xx_copy[2,2,2] = xx; real yy_rep = normal_rng(0, 1);}
"
m2 <- stan_model(model_code = mc2)
f2 <- gqs(m2, draws = as.matrix(f1))
```
