### PR TITLE
add missing default values to stan() arguments

### DIFF
--- a/rstan/rstan/man/stan.Rd
+++ b/rstan/rstan/man/stan.Rd
@@ -210,13 +210,15 @@ stan(file, model_name = "anon_model", model_code = "", fit = NA,
     In addition, algorithm HMC (called 'static HMC' in Stan) and NUTS share the
     following parameters:
     \itemize{
-      \item \code{stepsize} (\code{double}, positive)
-      \item \code{stepsize_jitter} (\code{double}, [0,1])
-      \item \code{metric} (\code{string}, one of "unit_e", "diag_e", "dense_e")
+      \item \code{stepsize} (\code{double}, positive, defaults to 1) 
+        Note: this controls the \emph{initial} stepsize only, unless \code{adapt_engaged=FALSE}.
+      \item \code{stepsize_jitter} (\code{double}, [0,1], defaults to 0)
+      \item \code{metric} (\code{string}, one of "unit_e", "diag_e", "dense_e", 
+      defaults to "diag_e")
     }
     For algorithm NUTS, we can also set:
     \itemize{
-      \item \code{max_treedepth} (\code{integer}, positive)
+      \item \code{max_treedepth} (\code{integer}, positive, defaults to 10)
     }
     For algorithm HMC, we can also set:
     \itemize{


### PR DESCRIPTION
#### Summary:

Closes #810

Documents default values for `stepsize`, `stepsize_jitter`, `metric`, and `max_treedepth`. 

#### How to Verify:

Read the changes to the doc. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
