### PR TITLE
avoid tbbmalloc_proxy loading & unloading for R below 4.0

### DIFF
--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -29,8 +29,9 @@ tbbmalloc_proxyDllInfo <- NULL
   Rcpp::loadModule("class_model_base", what = TRUE)
   Rcpp::loadModule("class_stan_fit", what = TRUE)
   ## the tbbmalloc_proxy is not loaded by RcppParallel which is linked
-  ## in by default on macOS
-  if(Sys.info()["sysname"] == "Darwin") {
+  ## in by default on macOS; unloading only works under R >= 4.0 so that
+  ## this is only done for R >= 4.0
+  if(R.version$major >= 4 && Sys.info()["sysname"] == "Darwin") {
       tbbmalloc_proxy  <- system.file("lib/libtbbmalloc_proxy.dylib", package="RcppParallel", mustWork=FALSE)
       tbbmalloc_proxyDllInfo <<- dyn.load(tbbmalloc_proxy, local = FALSE, now = TRUE)
   }


### PR DESCRIPTION
#### Summary:

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
