### PR TITLE
Fix #845 Update stanmodel-class.R

### DIFF
--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -234,7 +234,7 @@ setMethod("vb", "stanmodel",
 
             vbres <- sampler$call_sampler(c(args, dotlist))
             samples <- read_one_stan_csv(attr(vbres, "args")$sample_file)
-            diagnostic_columns <- which(grepl('__',colnames(samples)))[-1]
+            diagnostic_columns <- which(grepl('__$',colnames(samples)))[-1]
             if (length(diagnostic_columns)>0) {
               diagnostics <- samples[-1,diagnostic_columns]
               samples <- samples[,-diagnostic_columns]


### PR DESCRIPTION
Fix bug due to double underscores in parameter names #845 

#### Summary: 
Enables `vb` to handle parameters with double underscores in their names

#### Intended Effect: 
`vb` no longer errors when running model with parameter containing two consecutive underscores (e.g. `my__y`)

#### How to Verify: 
The following code no longer throws "incorrect number of dimensions" error
```
m <- stan_model(model_code = 'parameters {real my__y;} model {my__y ~ normal(0,1);}')
f <- vb(m, iter = 1)
```

#### Side Effects:
None

#### Documentation:
None needed

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
