### PR TITLE
sbc for models with pars declared and populated in one line

### DIFF
--- a/rstan/rstan/R/SBC.R
+++ b/rstan/rstan/R/SBC.R
@@ -15,10 +15,20 @@ sbc <- function(stanmodel, data, M, ..., save_progress, load_incomplete=FALSE) {
   stan_code <- get_stancode(stanmodel)
   stan_code <- scan(what = character(), sep = "\n", quiet = TRUE, text = stan_code)
   pars_lines <- grep("[[:space:]]*(pars_)|(pars_\\[.*\\])[[:space:]]*=", stan_code, value = TRUE)
-  pars_lines <- pars_lines[!grepl("^[[:space:]]*vector", pars_lines) & 
-                           !grepl("^[[:space:]]*real", pars_lines)]   
-  pars_names <- trimws(sapply(strsplit(pars_lines, split = "=", fixed = TRUE), tail, n = 1))
-  pars_names <- unique(sub("^([a-z,A-Z,0-9,_]*)_.*;", "\\1", pars_names))
+  if(length(pars_lines)==1){
+    # if the parameter was defined and assigned in one line:
+    pars_lines <- gsub(".*?=.*?(\\{|\\[)(.*?)(\\]|\\}).*","\\2",pars_lines)
+    pars_names <- trimws(strsplit(pars_lines, split = ",")[[1]])
+    pars_names <- unique(sub("^([a-z,A-Z,0-9,_]*)_.*", "\\1", 
+        pars_names))
+     } else {
+    pars_lines <- pars_lines[!grepl("^[[:space:]]*vector", pars_lines) & 
+        !grepl("^[[:space:]]*real", pars_lines)]
+    pars_names <- trimws(sapply(strsplit(pars_lines, split = "=", 
+        fixed = TRUE), tail, n = 1))
+    pars_names <- unique(sub("^([a-z,A-Z,0-9,_]*)_.*;", "\\1", 
+        pars_names))
+     }
   noUnderscore <- grepl(";", pars_names, fixed=TRUE)
   if (any(noUnderscore)) {
     warning(paste("The following parameters were added to pars_ but did not",


### PR DESCRIPTION
#### Summary:
These changes are related to this issue I found:
https://discourse.mc-stan.org/t/sbc-conventions/16579
sbc couldn't take models where parameters that are declared and populated in one line:
`  vector[3] pars_ = to_vector({alpha1_, alpha2_, beta_});`

#### Intended Effect:
Now it should work for a model like the one below:

#### How to Verify:
```
gamma <- "data {
  int<lower = 0> J;
}
transformed data {
  real<lower = 0> alpha_ = lognormal_rng(log(4), .1);
  real<lower = 0> beta_ = lognormal_rng(log(.5), .1);
  real y[J];
  for (j in 1:J){
       y[j]= gamma_rng(alpha_, beta_);
  }
}
parameters {
  real<lower=0> alpha;
  real<lower=0> beta;
}
transformed parameters {
}
model {
  target +=  lognormal_lpdf(alpha | log(4), .1);
  target +=  lognormal_lpdf(beta | log(.5), .1);
  target += gamma_lpdf(y| alpha, beta);
}
generated quantities {
  real y_[J] = y;
  vector[2] pars_= [alpha_, beta_]';
  int ranks_[2] = {alpha > alpha_, beta > beta_};
  vector[J] log_lik;
  for(j in 1:J)
    log_lik[j] = gamma_lpdf(y[j] | alpha, beta);
}
"
gamma_model <- rstan::stan_model(model_code = gamma)

output <- sbc(stanmodel = gamma_model,
              data = list(J = 100), M = 10,control=list(adapt_delta = .9) )

```

#### Side Effects:
-

#### Documentation:
-

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Bruno Nicenboim

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
