### PR TITLE
Remove duplicate dependency declaration

### DIFF
--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -62,8 +62,7 @@ Suggests:
     rstantools,
     rstudioapi,
     Matrix,
-    knitr (>= 1.15.1),
-    V8
+    knitr (>= 1.15.1)
 URL: https://mc-stan.org/rstan, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/rstan/issues/
 VignetteBuilder: knitr


### PR DESCRIPTION
V8 is already in imports, it is not needed anymore to have it in suggest.
