### PR TITLE
fix extract_sparse_parts for Matrix 1.3-0

### DIFF
--- a/rstan/rstan/R/extract_sparse_parts.R
+++ b/rstan/rstan/R/extract_sparse_parts.R
@@ -19,7 +19,7 @@ extract_sparse_parts <- function(A) {
   if (!requireNamespace("Matrix")) 
     stop("You have to install the Matrix package to call 'extract_sparse_parts'")
   if (!is(A, 'Matrix')) 
-    A <- Matrix::Matrix(A, sparse=TRUE)
+    A <- Matrix::Matrix(A, sparse=TRUE, doDiag=FALSE)
   A <- Matrix::t(A)
   A <- as(A, "dgCMatrix")
   return(.Call(extract_sparse_components, A))


### PR DESCRIPTION
#### Summary:

Due to a change in Matrix 1.3-0, extract_sparse_parts() fails for diagonal matrices. This small change fixes the issue.

#### How to Verify:

The code below currently fails when using Matrix 1.3-0, and the change is intended to fix it:

```
rstan::extract_sparse_parts(diag(3))
```

#### Documentation:

The NEWS for Matrix 1.3-0 describes the issue in detail:

 * 'Matrix(*, doDiag=TRUE)' where 'doDiag=TRUE' has always been
   the _default_ is now obeyed also in the sparse case, as all
   '"diagonalMatrix"' are also '"sparseMatrix"'.

   'Matrix(0, 3,3)' returns a '"ddiMatrix"' instead of a
   '"dsCMatrix"' previously.  The latter is still returned from
   'Matrix(0, 3,3, doDiag=FALSE)', and e.g.,
   '.symDiagonal(3,pi)'.

   Also a triangular matrix, e.g., '"dtrMatrix"' is detected
   now in cases with 'NA's.

   This is both a bug fix _and_ an API change which breaks code
   that assumes 'Matrix(.)' to return a '"CsparseMatrix"' in
   cases where it now returns a '"diagonalMatrix"' (which does
   extend '"sparseMatrix"').

#### Reviewer Suggestions: 
@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Edgar Merkle (self)

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
