### PR TITLE
Add "file://" protocol to stan_progress.html

### DIFF
--- a/rstan/rstan/inst/misc/stan_progress.html
+++ b/rstan/rstan/inst/misc/stan_progress.html
@@ -3,6 +3,6 @@
 <meta charset="utf-8">
 <title>%title%</title>
 </head>
-<iframe src="%filename%" style="width: 100%; height: 100%; border: 0">
+<iframe src="file://%filename%" style="width: 100%; height: 100%; border: 0">
 </iframe>
 </html>


### PR DESCRIPTION
#### Summary:

Adding the "file://" protocol to the beginning of the iframe increases compatibility with other browsers. Before, the update page would work in R Studio (which is why I think it hasn't been fixed so far) and using Edge/IE. Firefox complained about an invalid protocol, and would not display the page. After this simple change, it works as expected, and eliminates the need for "open_progress = FALSE" when using something else, like Emacs and ESS.

#### Intended Effect:

Increase compatibility of stan_progress.html with more browsers.

#### How to Verify:

Run a Stan model outside of R Studio with a non-Edge/IE default browser or open the HTML file created in the Temp directory.

#### Side Effects:

None

#### Documentation:

None needed.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
