### PR TITLE
use new RcppParallel API for resolving TBB when available

### DIFF
--- a/StanHeaders/R/Flags.R
+++ b/StanHeaders/R/Flags.R
@@ -7,9 +7,25 @@ CxxFlags <- function(as_character = FALSE) {
 }
 
 LdFlags <- function(as_character = FALSE) {
-  TBB <- system.file("lib", .Platform$r_arch, package = "RcppParallel", mustWork = TRUE)
+
+  # if RcppParallel provides the requisite API for querying
+  # the TBB library path, use it
+  TBB <- NULL
+  if (requireNamespace("RcppParallel", quietly = TRUE)) {
+    RcppParallel <- asNamespace("RcppParallel")
+    if (is.function(RcppParallel$tbbLibraryPath))
+      TBB <- RcppParallel$tbbLibraryPath()
+  }
+
+  # Otherwise, find it in the default location (for older RcppParallel releases)
+  if (is.null(TBB))
+    TBB <- system.file("lib", .Platform$r_arch, package = "RcppParallel", mustWork = TRUE)
+  
   PKG_LIBS <- paste0("-L", shQuote(TBB), " -Wl,-rpath,", shQuote(TBB), " -ltbb -ltbbmalloc")
-  if (isTRUE(as_character)) return(PKG_LIBS)
+  if (isTRUE(as_character))
+    return(PKG_LIBS)
+
   cat(PKG_LIBS, " ")
   return(invisible(NULL))
+
 }


### PR DESCRIPTION
#### Summary:

The development version of RcppParallel adds a function, `tbbLibraryPath()`, which can be used to query the version of TBB that RcppParallel has been configured to use.

#### Intended Effect:

Allow StanHeaders to remain compatible with the next release of RcppParallel.

#### How to Verify:

Test that `rstan` can be installed + compilation succeeds.

#### Side Effects:

None.

#### Documentation:

None required (no user-facing changes)

#### Reviewer Suggestions: 

None.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
