### PR TITLE
fix gqs with transformed parameters

### DIFF
--- a/rstan/rstan/R/stanmodel-class.R
+++ b/rstan/rstan/R/stanmodel-class.R
@@ -932,7 +932,8 @@ setMethod("gqs", "stanmodel",
   p_names <- unique(sub("\\..*$", "", sampler$constrained_param_names(TRUE, FALSE)))
   all_names <- sampler$constrained_param_names(TRUE, TRUE)
   some_names <- sampler$constrained_param_names(TRUE, FALSE)
-  draws_colnames <- sub("\\.", "[", some_names)
+  # exclude transformed parameters from draws
+  draws_colnames <- sub("\\.", "[", sampler$constrained_param_names(FALSE, FALSE))
   draws_colnames <- gsub("\\.", ",", draws_colnames)
   draws_colnames[grep("\\[", draws_colnames)] <- 
     paste0(draws_colnames[grep("\\[", draws_colnames)], "]")


### PR DESCRIPTION
#### Summary:

`gqs()` has an issue where it doesn't work with transformed parameters. (See #714)
If `draws` contains the transformed parameters, an error like the following occurs:

```
Wrong number of parameter values in draws from fitted model.  Expecting 2 columns, found 3 columns.
```
But if the offending transformed parameters are removed, we instead get the error:
```
Error in draws[, draws_colnames, drop = FALSE] : subscript out of bounds
```

#### Intended Effect:

This small change just strips the transformed parameters from `draws` (by looking at `constrained_param_names(FALSE, FALSE)`) before passing it to `standalone_gqs`.

#### How to Verify:

Here's some code (modified from #714) to test:

```R
library(rstan)
rstan_options(auto_write = TRUE)
options(mc.cores = parallel::detectCores())

stancode1 <- "
transformed data{
  vector[10] y = [4.65, 6.02, 4.92, 4.77, 8.12, 6.93, 7.39, 7.6, 5.68, 2.14]';
}
parameters{
  real mu;
  real log_sigma;
}
transformed parameters{
  real<lower=0> sigma = exp(log_sigma);
}
model{
  y ~ normal(mu, sigma);
  mu ~ normal(0, 10);
  log_sigma ~ normal(0, 2.5);
}
generated quantities{
  vector[10] y_rep;
  
  for (i in 1:10)
    y_rep[i] = normal_rng(mu, sigma);
}
"

stanmodel1 <- stan_model(model_code = stancode1)
fit1 <- sampling(stanmodel1)
rep <- gqs(stanmodel1, draws = as.matrix(fit1))
rep
```

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 
@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Joshua Moller-Mara

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
