### PR TITLE
Remove double V8 dependency

### DIFF
--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -39,8 +39,7 @@ Imports:
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
     loo (>= 2.3.0),
-    pkgbuild,
-    V8
+    pkgbuild
 Depends:
     R (>= 3.4.0),
     StanHeaders (>= 2.21.0),


### PR DESCRIPTION
This simple PR removes V8 from `Imports` which was apparently reintroduced sometime after it was moved to `Suggests`, resulting in it being listed twice in `DESCRIPTION`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
