### PR TITLE
Update check_hmc_diagnostics.Rd

### DIFF
--- a/rstan/rstan/man/check_hmc_diagnostics.Rd
+++ b/rstan/rstan/man/check_hmc_diagnostics.Rd
@@ -60,7 +60,7 @@ The \code{get_*} functions are for programmatic access to the diagnostics.
 \itemize{
 \item \code{get_divergent_iterations} and \code{get_max_treedepth_iterations} 
 return a logical vector indicating problems for individual iterations,
-\item \code{get_num_divergences} and \code{get_num_max_treedepth} return the 
+\item \code{get_num_divergent} and \code{get_num_max_treedepth} return the 
 number of offending interations, 
 \item \code{get_num_leapfrog_per_iteration} returns an integer vector with the 
 number of leapfrog evalutions for each iteration,


### PR DESCRIPTION
Noticed a small typo in `?(check_hmc_diagnostics)`.  Details states that `get_num_divergences` returns the number of divergent iterations, but looks like the function exported by rstan version 2.21.2 that accomplishes this is actually called `get_num_divergent`. Corrected here

#### Summary:

Typos in details, changed `get_num_divergences` to `get_num_divergent`

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
