### PR TITLE
Fix expose functions

### DIFF
--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -16,6 +16,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 expose_stan_functions_hacks <- function(code, includes = NULL) {
+  code <- paste("#ifndef MODELS_HPP",
+                      "#define MODELS_HPP",
+                      "#define STAN__SERVICES__COMMAND_HPP",
+                      "#include <rstan/rstaninc.hpp>",
+                      code,
+                      "#endif",
+                      sep = '\n')
   code <- paste("// [[Rcpp::depends(StanHeaders)]]",
                 "// [[Rcpp::depends(rstan)]]",
                 "// [[Rcpp::depends(RcppEigen)]]",

--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -16,13 +16,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 expose_stan_functions_hacks <- function(code, includes = NULL) {
-  code <- paste("#ifndef MODELS_HPP",
-                      "#define MODELS_HPP",
-                      "#define STAN__SERVICES__COMMAND_HPP",
-                      "#include <rstan/rstaninc.hpp>",
-                      code,
-                      "#endif",
-                      sep = '\n')
   code <- paste("// [[Rcpp::depends(StanHeaders)]]",
                 "// [[Rcpp::depends(rstan)]]",
                 "// [[Rcpp::depends(RcppEigen)]]",
@@ -31,6 +24,11 @@ expose_stan_functions_hacks <- function(code, includes = NULL) {
                 "#include <boost/integer/integer_log2.hpp>",
                 "#include <exporter.h>",
                 "#include <RcppEigen.h>",
+                "#ifndef MODELS_HPP",
+                "#define MODELS_HPP",
+                "#define STAN__SERVICES__COMMAND_HPP",
+                "#include <rstan/rstaninc.hpp>",
+                "#endif",
                 code, sep = "\n")
   code <- gsub("// [[stan::function]]",
                "// [[Rcpp::export]]", code, fixed = TRUE)

--- a/rstan/rstan/inst/NEWS
+++ b/rstan/rstan/inst/NEWS
@@ -2,6 +2,7 @@ Tue December 14, 2021
 
 1. Updated Stan to C++ compiler v2.28.2 (development).
 2. Used TBB source code from `RcppParallel`.
+3. Fixed `expose_stan_functions()` (#981).
 
 Mon October 18, 2021
 

--- a/rstan/rstan/tests/testthat.R
+++ b/rstan/rstan/tests/testthat.R
@@ -1,4 +1,6 @@
 library(testthat)
 library(rstan)
 
-test_check("rstan")
+# Have to test expose_stan_functions separately
+test_check("rstan",filter = "^((?!expose_stan_functions).)*$",perl=T)
+test_file("testthat/test-expose_stan_functions.R")

--- a/rstan/rstan/tests/testthat/test-expose_stan_functions.R
+++ b/rstan/rstan/tests/testthat/test-expose_stan_functions.R
@@ -1,0 +1,15 @@
+test_that("Exposing standalone function works", {
+  model_code <-
+  '
+  functions {
+    real standard_normal_rng() {
+      return normal_rng(0,1);
+    }
+  }
+  '
+
+  expose_stan_functions(stanc(model_code = model_code),
+                        env = environment(), rebuild = T)
+  PRNG <- get_rng(seed = 3)
+  expect_equal(standard_normal_rng(PRNG), 0.8825979695)
+})


### PR DESCRIPTION
#### Summary:

Fixes `expose_stan_functions` with rstan 2.26.x by updating the rstan includes

#### Intended Effect:

As above

#### How to Verify:

Tests included

#### Side Effects:

NA

#### Documentation:

NA

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
