### PR TITLE
Fix stanc_builder ignoring isystem

### DIFF
--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -122,7 +122,7 @@ stanc_builder <- function(file, isystem = c(dirname(file), getwd()),
 
   model_code <- stanc_process(file = file,
                               model_name = model_name,
-                              isystem = c(dirname(file), getwd()))
+                              isystem = isystem)
 
   out <- stanc(model_code = model_code,
                model_name = model_name, verbose = verbose,
@@ -157,7 +157,7 @@ stanc <- function(file, model_code = '', model_name = "anon_model",
   model_code <- stanc_process(file = file,
                               model_code = model_code,
                               model_name = model_name,
-                              isystem = c(dirname(file), getwd()))
+                              isystem = isystem)
 
   if (isTRUE(rstan_options("threads_per_chain") > 1L)) {
     Sys.setenv("STAN_NUM_THREADS" = rstan_options("threads_per_chain"))


### PR DESCRIPTION
#### Summary:

When `stanc_builder` calls `stanc_process` internally, it ignores the user-provided `isystem` value, defaulting to the current working directory. This PR fixes that.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
