### PR TITLE
Update plugin libs arg for inline and 4.2 compatibility

### DIFF
--- a/rstan/rstan/R/plugin.R
+++ b/rstan/rstan/R/plugin.R
@@ -121,7 +121,7 @@ rstanplugin <- function() {
   if (.Platform$OS.type == "windows") {
     list(includes = '// [[Rcpp::plugins(cpp14)]]\n',
          body = function(x) x,
-         env = list(LOCAL_LIBS = PL,
+         env = list(PKG_LIBS = PL,
                     PKG_CPPFLAGS = paste(Rcpp_plugin$env$PKG_CPPFLAGS,
                                          PKG_CPPFLAGS_env_fun(), collapse = " ")))
   } else {


### PR DESCRIPTION
@bgoodri or @jgabry, this PR fixes compatibility of rstan 2.21 with R4.2 (using the fix implemented by @hsbadr  for 2.26).

This resolves the errors seen in #1007 and [this forum post](https://discourse.mc-stan.org/t/after-trying-to-update-brms-cannot-run-model/20659/9)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
