### PR TITLE
Fix expose_stan_functions with dryRun

### DIFF
--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -102,7 +102,6 @@ expose_stan_functions <- function(stanmodel, includes = NULL,
     # workaround for packages with src/install.libs.R
       identical(Sys.getenv("WINDOWS"), "TRUE") &&
       !identical(Sys.getenv("R_PACKAGE_SOURCE"), "") )
-  if (inherits(compiled, "try-error")) stop("Compilation failed!")
   if (!isTRUE(show_compiler_warnings)) {
     sink(type = "output")
     close(zz)
@@ -116,6 +115,7 @@ expose_stan_functions <- function(stanmodel, includes = NULL,
   }
   DOTS <- list(...)
   if (isTRUE(DOTS$dryRun)) return(code)
+  if (inherits(compiled, "try-error")) stop("Compilation failed!")
   ENV <- DOTS$env
   if (is.null(ENV)) ENV <- globalenv()
   for (x in compiled$functions) {

--- a/rstan/rstan/tests/testthat/test-expose_dryRun.R
+++ b/rstan/rstan/tests/testthat/test-expose_dryRun.R
@@ -1,0 +1,10 @@
+test_that("expose_functions works with dryRun", {
+  funcode <- "
+    functions {
+      real rtn_real(real x) {
+        return x;
+      }
+    }"
+
+  expect_no_error(expose_stan_functions(stanc(model_code = funcode), dryRun = TRUE))
+})


### PR DESCRIPTION
The recent addition of the `try-error` check to `expose_stan_functions` has broken the use of the `dryRun = TRUE` argument, which has in turn broken the installation of packages which expose Stan functions (see this recent [rstantools PR workflow run](https://github.com/stan-dev/rstantools/actions/runs/4464720928) for an example).

This PR simply moves the check to after the early return for the `dryRun` argument, and adds a test to check that the error is resolved