### PR TITLE
Remove Eigen 3.4 requirement

### DIFF
--- a/StanHeaders/DESCRIPTION
+++ b/StanHeaders/DESCRIPTION
@@ -35,8 +35,7 @@ URL: https://mc-stan.org/
 Description: The C++ header files of the Stan project are provided by this package, but it contains little R code or documentation. The main reference is the vignette. There is a shared object containing part of the 'CVODES' library, but its functionality is not accessible from R. 'StanHeaders' is primarily useful for developers who want to utilize the 'LinkingTo' directive of their package's DESCRIPTION file to build on the Stan library without incurring unnecessary dependencies. The Stan project develops a probabilistic programming language that implements full or approximate Bayesian statistical inference via Markov Chain Monte Carlo or 'variational' methods and implements (optionally penalized) maximum likelihood estimation via optimization. The Stan library includes an advanced automatic differentiation scheme, 'templated' statistical and linear algebra functions that can handle the automatically 'differentiable' scalar types (and doubles, 'ints', etc.), and a parser for the Stan language. The 'rstan' package provides user-facing R functions to parse, compile, test, estimate, and analyze Stan models.
 Imports: RcppParallel (>= 5.1.4)
 Suggests: Rcpp, BH (>= 1.75.0-0), knitr (>= 1.36), rmarkdown, Matrix, methods, rstan
-LinkingTo: RcppEigen (>= 0.3.4.0.0), RcppParallel (>= 5.1.4)
-Remotes: hsbadr/RcppEigen@develop
+LinkingTo: RcppEigen (>= 0.3.3.9.3), RcppParallel (>= 5.1.4)
 VignetteBuilder: knitr
 SystemRequirements: GNU make, pandoc
 Depends: R (>= 3.4.0)

--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -48,11 +48,10 @@ Depends:
     StanHeaders (>= 2.31.0)
 LinkingTo:
     Rcpp (>= 1.0.7),
-    RcppEigen (>= 0.3.4.0.0),
+    RcppEigen (>= 0.3.3.9.3),
     BH (>= 1.75.0-0),
     StanHeaders (>= 2.31.0),
     RcppParallel (>= 5.1.4)
-Remotes: hsbadr/RcppEigen@develop
 Suggests:
     testthat (>= 3.0.4),
     parallel,


### PR DESCRIPTION
This PR drops the RcppEigen 3.4 requirement down to 3.3.9 (current RcppEigen CRAN version). I've run the reverse-dependency checks with the change made, and all packages (or their respective compatibility PRs from #1053) are passing.
