### PR TITLE
Fix extract_sparse_parts for Matrix 1.5-0

### DIFF
--- a/rstan/rstan/R/extract_sparse_parts.R
+++ b/rstan/rstan/R/extract_sparse_parts.R
@@ -21,6 +21,6 @@ extract_sparse_parts <- function(A) {
   if (!is(A, 'Matrix')) 
     A <- Matrix::Matrix(A, sparse=TRUE, doDiag=FALSE)
   A <- Matrix::t(A)
-  A <- as(A, "dgCMatrix")
+  A <- as(A, "dMatrix")
   return(.Call(extract_sparse_components, A))
 }


### PR DESCRIPTION
#### Summary:
When running extract_sparse_parts with a binary matrix (only zeros and once), a deprecation warning is issued.
`as(<lgCMatrix>, "dgCMatrix") `is deprecated since Matrix 1.5-0; it is now recommended to use `as(., "dMatrix")` instead

#### Intended Effect:
No deprecation warning thrown anymore.

#### How to Verify:

#### Side Effects:
None

#### Documentation:
No update needed

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Adrian Lison

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
