### PR TITLE
Allow V8 namespace check to fail quietly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
+          _R_CHECK_FORCE_SUGGESTS_: false
         run: |
           if (R.version$major < 4 && isTRUE(.Platform$OS.type == "windows")) {
             dotR <- file.path(Sys.getenv("HOME"), ".R")

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -20,7 +20,7 @@ RNG <- 0
 OUT <- 0
 
 .onLoad <- function(libname, pkgname) {
-  if (requireNamespace("V8")) {
+  if (requireNamespace("V8", quietly = TRUE)) {
     assign("stanc_ctx", V8::v8(), envir = topenv())
   } else assign("stanc_ctx", QuickJSR::JSContext$new(stack_size = 4 * 1024 * 1024), envir = topenv())
   stanc_js <- system.file("stanc.js", package = "StanHeaders", mustWork = TRUE)


### PR DESCRIPTION
#### Summary:

The namespace check for V8 will currently cause the installation to error and fail if V8 isn't installed, we need to add `quietly = TRUE`