### PR TITLE
Update expose_stan_functions flags for c++17

### DIFF
--- a/rstan/rstan/R/cxxfunplus.R
+++ b/rstan/rstan/R/cxxfunplus.R
@@ -142,14 +142,12 @@ cxxfunctionplus <- function(sig = character(), body = character(),
                             ..., verbose = FALSE) {
   R_version <- with(R.version, paste(major, minor, sep = "."))
   WINDOWS <- .Platform$OS.type == "windows"
-  if (WINDOWS && R_version < "3.7.0") {
-    has_USE_CXX11 <- Sys.getenv("USE_CXX11") != ""
-    Sys.setenv(USE_CXX11 = 1) # -std=c++1y gets added anyways
-    if (!has_USE_CXX11) on.exit(Sys.unsetenv("USE_CXX11"))
+  if (WINDOWS && R.version$major < 4) {
+    stop("cxxfunctionplus requires R >= 4.0 on Windows to use C++17")
   } else {
-    has_USE_CXX14 <- Sys.getenv("USE_CXX14") != ""
-    Sys.setenv(USE_CXX14 = 1)
-    if (!has_USE_CXX14) on.exit(Sys.unsetenv("USE_CXX14"))
+    has_USE_CXX17 <- Sys.getenv("USE_CXX17") != ""
+    Sys.setenv(USE_CXX17 = 1)
+    if (!has_USE_CXX17) on.exit(Sys.unsetenv("USE_CXX17"))
   }
   if (rstan_options("required"))
     pkgbuild::has_build_tools(debug = FALSE) ||
@@ -183,11 +181,6 @@ cxxfunctionplus <- function(sig = character(), body = character(),
     close(zz)
     try(file.remove(tf), silent = TRUE)
     on.exit(NULL)
-    if (WINDOWS && R_version < "3.7.0") {
-      if (!has_USE_CXX11) on.exit(Sys.unsetenv("USE_CXX11"), add = TRUE)
-    } else {
-      if (!has_USE_CXX14) on.exit(Sys.unsetenv("USE_CXX14"), add = TRUE)
-    }
   }
   dso_last_path <- dso_path(fx)
   if (grepl("^darwin", R.version$os) && grepl("clang", get_CXX(FALSE))) {

--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -66,15 +66,12 @@ expose_stan_functions <- function(stanmodel, includes = NULL,
   code <- expose_stan_functions_hacks(r$cppcode, includes)
 
   WINDOWS <- .Platform$OS.type == "windows"
-  R_version <- with(R.version, paste(major, minor, sep = "."))
-  if (WINDOWS && R_version < "3.7.0") {
-    has_USE_CXX11 <- Sys.getenv("USE_CXX11") != ""
-    Sys.setenv(USE_CXX11 = 1) # -std=c++1y gets added anyways
-    if (!has_USE_CXX11) on.exit(Sys.unsetenv("USE_CXX11"))
+  if (WINDOWS && R.version$major < 4) {
+    stop("expose_stan_functions requires R >= 4.0 on Windows to use C++17")
   } else {
-    has_USE_CXX14 <- Sys.getenv("USE_CXX14") != ""
-    Sys.setenv(USE_CXX14 = 1)
-    if (!has_USE_CXX14) on.exit(Sys.unsetenv("USE_CXX14"))
+    has_USE_CXX17 <- Sys.getenv("USE_CXX17") != ""
+    Sys.setenv(USE_CXX17 = 1)
+    if (!has_USE_CXX17) on.exit(Sys.unsetenv("USE_CXX17"))
   }
 
   if (rstan_options("required"))
@@ -109,11 +106,6 @@ expose_stan_functions <- function(stanmodel, includes = NULL,
     close(zz)
     try(file.remove(tf), silent = TRUE)
     on.exit(NULL)
-    if (WINDOWS && R_version < "3.7.0") {
-      if (!has_USE_CXX11) on.exit(Sys.unsetenv("USE_CXX11"), add = TRUE)
-    } else {
-      if (!has_USE_CXX14) on.exit(Sys.unsetenv("USE_CXX14"), add = TRUE)
-    }
   }
   DOTS <- list(...)
   if (isTRUE(DOTS$dryRun)) return(code)

--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -1650,19 +1650,17 @@ create_progress_html_file <- function(htmlfname, textfname) {
   cat(src2, file = htmlfname)
 }
 
-get_CXX <- function(CXX14 = TRUE) {
+get_CXX <- function(...) {
   if (.Platform$OS.type != "windows")
     return (system2(file.path(R.home(component = "bin"), "R"),
-            args = paste("CMD config", ifelse(CXX14, "CXX14", "CXX11")),
-            stdout = TRUE, stderr = FALSE))
+            args = "CMD config CXX17", stdout = TRUE, stderr = FALSE))
 
-    ls_path <- Sys.which("ls")
-    if (ls_path == "")
-        return(NULL)
+  ls_path <- Sys.which("ls")
+  if (ls_path == "") return(NULL)
 
-    install_path <- dirname(dirname(ls_path))
-    file.path(install_path,
-              paste0('mingw_', Sys.getenv('WIN')), 'bin', 'g++')
+  install_path <- dirname(dirname(ls_path))
+  file.path(install_path,
+            paste0('mingw_', Sys.getenv('WIN')), 'bin', 'g++')
 }
 
 is.sparc <- function() {

--- a/rstan/rstan/R/plugin.R
+++ b/rstan/rstan/R/plugin.R
@@ -38,8 +38,8 @@ boost_path_fun2 <- function() {
 }
 
 PKG_CPPFLAGS_env_fun <- function() {
-   Eigen <- dir(system.file("include", "stan", "math", "prim", 
-                            package = "StanHeaders", mustWork = TRUE), 
+   Eigen <- dir(system.file("include", "stan", "math", "prim",
+                            package = "StanHeaders", mustWork = TRUE),
                 pattern = "Eigen.hpp$", full.names = TRUE, recursive = TRUE)[1]
    paste(' -I"', file.path(inc_path_fun("Rcpp"), '" '),
          ' -I"', file.path(eigen_path_fun(), '" '),
@@ -58,7 +58,7 @@ PKG_CPPFLAGS_env_fun <- function() {
          ' -DUSE_STANC3',
          ' -DSTRICT_R_HEADERS ',
          ' -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION ',
-         ' -DBOOST_NO_AUTO_PTR ',
+         ' -D_HAS_AUTO_PTR_ETC=0 ',
          ' -include ', shQuote(Eigen), ' ',
          ifelse (.Platform$OS.type == "windows", ' -std=c++1y',
                  ' -D_REENTRANT -DRCPP_PARALLEL_USE_TBB=1 '),
@@ -145,4 +145,3 @@ inlineCxxPlugin <- function(...) {
   settings <- rstanplugin()
   settings
 }
-

--- a/rstan/rstan/R/stan_plot_helpers.R
+++ b/rstan/rstan/R/stan_plot_helpers.R
@@ -593,6 +593,7 @@ color_vector_chain <- function(n) {
   mdf <- cbind(mdf_td, div = mdf_nd$value)
   plot_data <- if (divergent == "All") mdf else mdf[mdf$div == divergent, , drop = FALSE]
   if (nrow(plot_data) == 0) return(NULL)
+  count <- NaN
 
   graph <- ggplot2::ggplot(
     data = plot_data,

--- a/rstan/rstan/src/Makevars
+++ b/rstan/rstan/src/Makevars
@@ -1,5 +1,4 @@
 CXX_STD = CXX17
-CXX14STD = -std=c++1y
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))" | tail -n 1)
 PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DUSE_STANC3 -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
 PKG_CPPFLAGS += $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::CxxFlags()" | tail -n 1)

--- a/rstan/rstan/src/Makevars.win
+++ b/rstan/rstan/src/Makevars.win
@@ -1,5 +1,4 @@
 CXX_STD = CXX17
-CXX14STD = -std=c++1y
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))" | tail -n 1)
 PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DUSE_STANC3 -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
 PKG_CPPFLAGS += $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::CxxFlags()" | tail -n 1)


### PR DESCRIPTION
#### Summary:

`expose_stan_functions` fails under c++17 as the Rcpp plugin is missing the updated Boost flags. This is causing rstanarm test failures on CRAN: https://github.com/stan-dev/rstanarm/issues/601

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
