### PR TITLE
Fix js lookup syntax error

### DIFF
--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -24,7 +24,7 @@ OUT <- 0
     assign("stanc_ctx", V8::v8(), envir = topenv())
   } else assign("stanc_ctx", QuickJSR::JSContext$new(stack_size = 4 * 1024 * 1024), envir = topenv())
   stanc_js <- system.file("stanc.js", package = "StanHeaders", mustWork = TRUE)
-  if (!stanc_ctx$validate(stanc_js)) {
+  if (!file.exists(stanc_js)) {
     stanc_js <- system.file("exec", "stanc.js", package = "rstan", mustWork = TRUE)
   }
   stanc_ctx$source(stanc_js)


### PR DESCRIPTION
#### Summary:

The `onLoad` action for `rstan` currently uses the `$validate()` member function to check the `stanc.js` in `StanHeaders`, and if the check fails then loads the `stanc.js` from `rstan`. However, `$validate()` assumes that the input is a string of JS code, not a file path. This means that the check is always `FALSE`, and the `rstan` `stanc.js` is always loaded.

This PR simplifies that to just checking whether the file exists.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
