### PR TITLE
Fix LdFlags for new RcppParallel

### DIFF
--- a/StanHeaders/R/Flags.R
+++ b/StanHeaders/R/Flags.R
@@ -17,8 +17,9 @@ CxxFlags <- function(as_character = FALSE) {
 }
 
 LdFlags <- function(as_character = FALSE) {
-  if (dir.exists(Sys.getenv("TBB_LIB"))) {
-    TBB_LIB <- normalizePath(Sys.getenv("TBB_LIB"))
+  TBB_LIB <- Sys.getenv("TBB_LINK_LIB", Sys.getenv("TBB_LIB"))
+  if (dir.exists(TBB_LIB)) {
+    TBB_LIB <- normalizePath(TBB_LIB)
   } else {
     TBB_LIB <- system.file("lib", .Platform$r_arch, package = "RcppParallel", mustWork = TRUE)
   }


### PR DESCRIPTION
#### Summary:

This copies a small tweak from RcppParallel to support cross compiling, see: https://github.com/RcppCore/RcppParallel/pull/208

Basically we check `$TBB_LINK_LIB` before checking `$TBB_LIB` which is needed when the runtime arch (TBB_LIB) is different from the one we are compiling for (`TBB_LINK_LIB`)





#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Jeroen Ooms

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
