### PR TITLE
fix rosetta indexing in lookup()

### DIFF
--- a/rstan/rstan/R/lookup.R
+++ b/rstan/rstan/R/lookup.R
@@ -27,14 +27,16 @@ lookup <- function(FUN, ReturnType = character()) {
   if(is.function(FUN)) FUN <- deparse(substitute(FUN))
   if(!is.character(FUN)) stop("'FUN' must be a character string for a function")
   if(length(FUN) != 1) stop("'FUN' must be of length one")
-  
+
   if(FUN == "nrow") FUN <- "NROW"
   if(FUN == "ncol") FUN <- "NCOL"
+
+  keep_cols <- !(colnames(rosetta) == "RFunction")
   if(exists(FUN)) {
     matches <- as.logical(charmatch(rosetta$RFunction, FUN, nomatch = 0L))
-    if(any(matches)) return(rosetta[matches,-1,drop=FALSE])
+    if(any(matches)) return(rosetta[matches, keep_cols, drop = FALSE])
   }
   matches <- grepl(FUN, rosetta$StanFunction, ignore.case = TRUE)
-  if(any(matches)) return(rosetta[matches,-1,drop=FALSE])
+  if(any(matches)) return(rosetta[matches, keep_cols, drop = FALSE])
   else return("no matching Stan functions")
 }

--- a/rstan/rstan/R/lookup.R
+++ b/rstan/rstan/R/lookup.R
@@ -31,7 +31,7 @@ lookup <- function(FUN, ReturnType = character()) {
   if(FUN == "nrow") FUN <- "NROW"
   if(FUN == "ncol") FUN <- "NCOL"
 
-  keep_cols <- !(colnames(rosetta) == "RFunction")
+  keep_cols <- colnames(rosetta) != "RFunction"
   if(exists(FUN)) {
     matches <- as.logical(charmatch(rosetta$RFunction, FUN, nomatch = 0L))
     if(any(matches)) return(rosetta[matches, keep_cols, drop = FALSE])


### PR DESCRIPTION
closes #1110

#### Summary:

`lookup()` is now dropping the wrong column of the rosetta table, as pointed out in #1110. This PR makes `lookup()` less error prone by dropping the `RFunction` column by name instead of by column number. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
