### PR TITLE
Catch last space in regex in `expose_stan_functions`

### DIFF
--- a/rstan/rstan/R/expose_stan_functions.R
+++ b/rstan/rstan/R/expose_stan_functions.R
@@ -30,7 +30,7 @@ expose_stan_functions_hacks <- function(code, includes = NULL) {
                 code, sep = "\n")
   code <- gsub("// [[stan::function]]",
                "// [[Rcpp::export]]", code, fixed = TRUE)
-  code <- gsub("stan::math::accumulator<double>& lp_accum__,(\\n)?(\\s*)?std::ostream\\*(\\n)?(\\s*)?pstream__(\\n)?(\\s*)?=(\\n)?\\s*)?(nullptr|0))(\\s*)?\\{",
+  code <- gsub("stan::math::accumulator<double>&(\\s*)?lp_accum__,(\\n)?(\\s*)?std::ostream\\*(\\n)?(\\s*)?pstream__(\\n)?(\\s*)?=(\\n)?\\s*)?(nullptr|0))(\\s*)?\\{",
                "std::ostream* pstream__ = nullptr){\nstan::math::accumulator<double> lp_accum__;",
                code)
   code <- gsub("pstream__(\\s*|)=(\\s*|)nullptr", "pstream__ = 0", code)


### PR DESCRIPTION
#### Summary:
Fixes #1114 by catching the last space in the regex for `expose_stan_functions`, which can be a line break.
Previous PRs #1094 and #1099 did not completely fix this problem. Scanning the culpable line this should be the last one to fix.

#### Intended Effect:
Example in Issue #1114 works.

#### How to Verify:
Text example in Issue #1114

#### Side Effects:
None

#### Documentation:
n/a

#### Reviewer Suggestions: 
@andrjohns (sorry, once more)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian funk

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
