### PR TITLE
stanc: preserve blank lines in source

### DIFF
--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -54,7 +54,7 @@ stanc_process <- function(file, model_code = '', model_name = "anon_model",
     model_name <- attr(model_code, "model_name2")
 
   model_attr <- attributes(model_code)
-  model_code <- scan(text = model_code, what = character(), sep = "\n", quiet = TRUE)
+  model_code <- scan(text = model_code, what = character(), sep = "\n", quiet = TRUE, blank.lines.skip=FALSE)
 
   # Remove trailing whitespaces
   model_code <- trimws(model_code, "r")


### PR DESCRIPTION
#### Summary:

This adds the `blank.lines.skip=FALSE` argument to `scan` used in `stanc_process`, which fixes the issue where line numbers reported by stanc did not match the source in compiler or runtime errors.

#### Intended Effect:
Closes #1123 

#### How to Verify:

The code in #1123 now yields a straight line plot as expected

#### Side Effects:

None
#### Documentation:

None

#### Reviewer Suggestions: 

@bgoodri @andrjohns 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
