### PR TITLE
Fix stan CSV parsing for save warmups 

### DIFF
--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -111,7 +111,7 @@ parse_stancsv_comments <- function(comments) {
   names2 <- intersect(c("stepsize", "stepsize_jitter", "adapt_gamma", "adapt_kappa", 
                         "adapt_delta", "gamma", "kappa", "delta", "t0",
                         "adapt_t0"), names0) 
-  if ("save_warmup" %in% names(values) values[["save_warmup"]] <- as.integer(as.logical(values[["save_warmup"]]))
+  if ("save_warmup" %in% names(values)) values[["save_warmup"]] <- as.integer(as.logical(values[["save_warmup"]]))
   for (z in names1) values[[z]] <- as.integer(values[[z]])
   for (z in names2) values[[z]] <- as.numeric(values[[z]])
   if (compute_iter) values[["iter"]] <- values[["iter"]] + values[["warmup"]]

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -107,10 +107,11 @@ parse_stancsv_comments <- function(comments) {
   } 
   names1 <- intersect(c("thin", "iter", "warmup", "chain_id", "max_depth", 
                         "num_samples", "num_warmup", "id",
-                        "max_treedepth", "save_warmup"), names0)
+                        "max_treedepth"), names0)
   names2 <- intersect(c("stepsize", "stepsize_jitter", "adapt_gamma", "adapt_kappa", 
                         "adapt_delta", "gamma", "kappa", "delta", "t0",
                         "adapt_t0"), names0) 
+  values[["save_warmup"]] <- as.integer(as.logical(values[["save_warmup"]]))
   for (z in names1) values[[z]] <- as.integer(values[[z]])
   for (z in names2) values[[z]] <- as.numeric(values[[z]])
   if (compute_iter) values[["iter"]] <- values[["iter"]] + values[["warmup"]]

--- a/rstan/rstan/R/stan_csv.R
+++ b/rstan/rstan/R/stan_csv.R
@@ -111,7 +111,7 @@ parse_stancsv_comments <- function(comments) {
   names2 <- intersect(c("stepsize", "stepsize_jitter", "adapt_gamma", "adapt_kappa", 
                         "adapt_delta", "gamma", "kappa", "delta", "t0",
                         "adapt_t0"), names0) 
-  values[["save_warmup"]] <- as.integer(as.logical(values[["save_warmup"]]))
+  if ("save_warmup" %in% names(values) values[["save_warmup"]] <- as.integer(as.logical(values[["save_warmup"]]))
   for (z in names1) values[[z]] <- as.integer(values[[z]])
   for (z in names2) values[[z]] <- as.numeric(values[[z]])
   if (compute_iter) values[["iter"]] <- values[["iter"]] + values[["warmup"]]


### PR DESCRIPTION
#### Summary:
Currently there is bug in parsing stan CSV output files to turn into rstanfit object using `read_stan_csv` which results in NA value for the field `save_warmup` resulting in the error

```R
r$>  rstan::read_stan_csv(cmdstan_m_robit_3pl$output_files())
Error in if (max(save_warmup) == 0L) { : 
  missing value where TRUE/FALSE needed
In addition: Warning message:
In parse_stancsv_comments(comments) : NAs introduced by coercion
```

#### Intended Effect:


#### How to Verify:
using package versions: cmdstanr_0.8.1     rstan_2.32.6  

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
