### PR TITLE
.Call() with symbols, not strings

### DIFF
--- a/rstan/rstan/R/get_rng.R
+++ b/rstan/rstan/R/get_rng.R
@@ -3,8 +3,5 @@ get_rng <- function(seed=0L) {
     if (length(seed) != 1) 
       stop("Seed must be a length-1 integer vector.")
   }
-  return(.Call('get_rng_', seed))
+  return(.Call(get_rng_, seed))
 }
-
-
-

--- a/rstan/rstan/R/get_stream.R
+++ b/rstan/rstan/R/get_stream.R
@@ -1,5 +1,5 @@
 get_stream <- function() {
-  return(.Call('get_stream_'))
+  return(.Call(get_stream_))
 }
 
 


### PR DESCRIPTION
On my (rather baroque!) installation of R 4.4.1, `loadNamespace("rstan")` fails:

```
Error: package or namespace load failed for ‘rstan’:
 .onLoad failed in loadNamespace() for 'rstan', details:
  call: get_rng(0)
  error: DLL requires the use of native symbols
Error: loading failed
```

Per https://stackoverflow.com/q/76689311/3576984, there seems to be some (ongoing?) evolution on supplying routine names as strings, _when they're registered and available as symbols_.

Regardless of whether this is causing errors, I _do_ think using the symbols when possible is preferable, hence filing this PR even though the issue I observe is not necessarily reproducible. c.f. [`lintr::routine_registration_linter()`](https://lintr.r-lib.org/reference/routine_registration_linter.html).