### PR TITLE
pairs.R: evaluate in parent.frame() (maybe)

### DIFF
--- a/rstan/rstan/R/pairs.R
+++ b/rstan/rstan/R/pairs.R
@@ -204,5 +204,5 @@ pairs.stanfit <-
     mc$condition <- NULL
     mc$pars <- NULL
     mc$include <- NULL
-    eval(mc)
+    eval(mc, parent.frame())
   }


### PR DESCRIPTION
#### Summary:

Fixes #1155, although this might not be the preferred solution. This PR changes pairs.stanfit so evaluation takes place in the calling environment, which avoids the error in #1155. **However**, this approach could have unintended consequences, so I'm not sure whether we should actually do this.  


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
