### PR TITLE
Replace non-API EXTPTR_PTR with R_ExternalPtrAddr

### DIFF
--- a/rstan/rstan/src/misc.cpp
+++ b/rstan/rstan/src/misc.cpp
@@ -44,10 +44,8 @@ SEXP is_Null_NS(SEXP ns) {
   LOGICAL(ans)[0] = 1;
   PROTECT(ns);
   if (TYPEOF(ns) == EXTPTRSXP) {
-    // Rprintf("ptr=%p.\n", EXTPTR_PTR(ns));
-    if (EXTPTR_PTR(ns) != NULL) LOGICAL(ans)[0] = 0;
+    if (R_ExternalPtrAddr(ns) != NULL) LOGICAL(ans)[0] = 0;
   }
   UNPROTECT(2);
   return ans;
 }
-


### PR DESCRIPTION
#### Summary:

rstan's [CRAN check results](https://cran.r-project.org/web/checks/check_results_rstan.html) are currently giving a `NOTE` for non-API entry points:

```
Version: 2.32.6
Check: compiled code
Result: NOTE
  File ‘rstan/libs/rstan.so’:
    Found non-API call to R: ‘EXTPTR_PTR’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
  and section ‘Moving into C API compliance’ for issues with the use of
  non-API entry points.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/rstan-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/rstan-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/rstan-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/rstan-00check.html)
```

This can be resolved by replacing (the single usage) of `EXTPTR_PTR` with `R_ExternalPtrAddr`, like `Rcpp` [previously had to do](https://github.com/RcppCore/Rcpp/issues/1097)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
