### PR TITLE
Use Stan's rng_t typedef instead of hardcoding

### DIFF
--- a/rstan/rstan/R/Rcpp_module_def.R
+++ b/rstan/rstan/R/Rcpp_module_def.R
@@ -19,61 +19,61 @@ get_Rcpp_module_def_code <- function(model_name) {
   RCPP_MODULE <-
 '
 RCPP_MODULE(stan_fit4%model_name%_mod) {
-  class_<rstan::stan_fit<stan_model, boost::random::mixmax> >(
+  class_<rstan::stan_fit<stan_model, stan::rng_t> >(
       "stan_fit4%model_name%")
 
       .constructor<SEXP, SEXP, SEXP>()
 
       .method(
           "call_sampler",
-          &rstan::stan_fit<stan_model, boost::random::mixmax>::call_sampler)
+          &rstan::stan_fit<stan_model, stan::rng_t>::call_sampler)
       .method(
           "param_names",
-          &rstan::stan_fit<stan_model, boost::random::mixmax>::param_names)
+          &rstan::stan_fit<stan_model, stan::rng_t>::param_names)
       .method("param_names_oi",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::param_names_oi)
+                               stan::rng_t>::param_names_oi)
       .method("param_fnames_oi",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::param_fnames_oi)
+                               stan::rng_t>::param_fnames_oi)
       .method(
           "param_dims",
-          &rstan::stan_fit<stan_model, boost::random::mixmax>::param_dims)
+          &rstan::stan_fit<stan_model, stan::rng_t>::param_dims)
       .method("param_dims_oi",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::param_dims_oi)
+                               stan::rng_t>::param_dims_oi)
       .method("update_param_oi",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::update_param_oi)
+                               stan::rng_t>::update_param_oi)
       .method("param_oi_tidx",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::param_oi_tidx)
+                               stan::rng_t>::param_oi_tidx)
       .method("grad_log_prob",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::grad_log_prob)
+                               stan::rng_t>::grad_log_prob)
       .method("log_prob",
-              &rstan::stan_fit<stan_model, boost::random::mixmax>::log_prob)
+              &rstan::stan_fit<stan_model, stan::rng_t>::log_prob)
       .method("unconstrain_pars",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::unconstrain_pars)
+                               stan::rng_t>::unconstrain_pars)
       .method("constrain_pars",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::constrain_pars)
+                               stan::rng_t>::constrain_pars)
       .method(
           "num_pars_unconstrained",
           &rstan::stan_fit<stan_model,
-                           boost::random::mixmax>::num_pars_unconstrained)
+                           stan::rng_t>::num_pars_unconstrained)
       .method(
           "unconstrained_param_names",
           &rstan::stan_fit<
-              stan_model, boost::random::mixmax>::unconstrained_param_names)
+              stan_model, stan::rng_t>::unconstrained_param_names)
       .method(
           "constrained_param_names",
           &rstan::stan_fit<stan_model,
-                           boost::random::mixmax>::constrained_param_names)
+                           stan::rng_t>::constrained_param_names)
       .method("standalone_gqs",
               &rstan::stan_fit<stan_model,
-                               boost::random::mixmax>::standalone_gqs);
+                               stan::rng_t>::standalone_gqs);
 }
 '
 gsub("%model_name%", model_name, RCPP_MODULE)

--- a/rstan/rstan/R/doctor_cppcode.R
+++ b/rstan/rstan/R/doctor_cppcode.R
@@ -64,7 +64,7 @@ doctor_cppcode <- function(stanc_ret,
                              "boost_random_R base_rng__ = boost_random_R();")
   } else { # this could be dangerous to use with parallel chains
     protected$PRNG <- paste0(four_spaces,
-                             "mutable boost::random::mixmax base_rng__;")
+                             "mutable stan::rng_t base_rng__;")
   }
 
   if (check_logical_scalar_first(use_Rcout)) {
@@ -121,7 +121,7 @@ doctor_cppcode <- function(stanc_ret,
     lines <- gsub("typename T_lp_accum__", "typename T_lp_accum__ = double", lines)
     lines <- gsub("Class RNG",
                   paste0("Class RNG = ", ifelse(use_R_PRNG, "boost_random_R",
-                                                "boost::random::mixmax")), lines)
+                                                "stan::rng_t")), lines)
   }
 
   if (check_logical_scalar_first(double_only)) {
@@ -240,8 +240,7 @@ doctor_cppcode <- function(stanc_ret,
                            "#include <boost/exception/all.hpp>")
     if (!use_R_PRNG)
       necessary_headers <- c(necessary_headers,
-                             "#include <boost/random/mixmax.hpp>",
-                             "#include <boost/random/linear_congruential.hpp>")
+                             "#include <stan/services/util/create_rng.hpp>")
 
   }
 
@@ -478,7 +477,7 @@ doctor_cppcode <- function(stanc_ret,
   }
 
   # do not create base_rng__ in ctor_body
-  mark <- grep("boost::random::mixmax base_rng__ =", lines, fixed = TRUE)
+  mark <- grep("stan::rng_t base_rng__ =", lines, fixed = TRUE)
   lines <- lines[-c(mark:(mark + 2L))]
 
   # deal with constructor

--- a/rstan/rstan/inst/include/exporter.h
+++ b/rstan/rstan/inst/include/exporter.h
@@ -2,19 +2,19 @@
 #define RSTAN_EXPORTER_H
 
 #include <RcppCommon.h>
-#include <boost/random/mixmax.hpp>
+#include <stan/services/util/create_rng.hpp>
 #include <iostream>
 
 namespace Rcpp {
-  SEXP wrap(boost::random::mixmax RNG);
-  SEXP wrap(boost::random::mixmax& RNG);
+  SEXP wrap(stan::rng_t RNG);
+  SEXP wrap(stan::rng_t& RNG);
   SEXP wrap(std::ostream stream);
-  template <> boost::random::mixmax as(SEXP ptr_RNG);
-  template <> boost::random::mixmax& as(SEXP ptr_RNG);
+  template <> stan::rng_t as(SEXP ptr_RNG);
+  template <> stan::rng_t& as(SEXP ptr_RNG);
   template <> std::ostream* as(SEXP ptr_stream);
   namespace traits {
-    template <> class Exporter<boost::random::mixmax&>;
-    template <> struct input_parameter<boost::random::mixmax&>;
+    template <> class Exporter<stan::rng_t&>;
+    template <> struct input_parameter<stan::rng_t&>;
   }
 }
 
@@ -22,15 +22,15 @@ namespace Rcpp {
 #include <Rcpp.h>
 
 namespace Rcpp {
-  SEXP wrap(boost::random::mixmax RNG){
-    boost::random::mixmax* ptr_RNG = &RNG;
-    Rcpp::XPtr<boost::random::mixmax> Xptr_RNG(ptr_RNG);
+  SEXP wrap(stan::rng_t RNG){
+    stan::rng_t* ptr_RNG = &RNG;
+    Rcpp::XPtr<stan::rng_t> Xptr_RNG(ptr_RNG);
     return Xptr_RNG;
   }
 
-  SEXP wrap(boost::random::mixmax& RNG){
-    boost::random::mixmax* ptr_RNG = &RNG;
-    Rcpp::XPtr<boost::random::mixmax> Xptr_RNG(ptr_RNG);
+  SEXP wrap(stan::rng_t& RNG){
+    stan::rng_t* ptr_RNG = &RNG;
+    Rcpp::XPtr<stan::rng_t> Xptr_RNG(ptr_RNG);
     return Xptr_RNG;
   }
 
@@ -40,15 +40,15 @@ namespace Rcpp {
     return Xptr_stream;
   }
 
-  template <> boost::random::mixmax as(SEXP ptr_RNG) {
-    Rcpp::XPtr<boost::random::mixmax> ptr(ptr_RNG);
-    boost::random::mixmax& RNG = *ptr; 
+  template <> stan::rng_t as(SEXP ptr_RNG) {
+    Rcpp::XPtr<stan::rng_t> ptr(ptr_RNG);
+    stan::rng_t& RNG = *ptr;
  		return RNG;
   }
 
-  template <> boost::random::mixmax& as(SEXP ptr_RNG) {
-    Rcpp::XPtr<boost::random::mixmax> ptr(ptr_RNG);
-    boost::random::mixmax& RNG = *ptr; 
+  template <> stan::rng_t& as(SEXP ptr_RNG) {
+    Rcpp::XPtr<stan::rng_t> ptr(ptr_RNG);
+    stan::rng_t& RNG = *ptr;
  		return RNG;
   }
 
@@ -59,18 +59,18 @@ namespace Rcpp {
 
 
   namespace traits {
-    template <> class Exporter<boost::random::mixmax&> {
+    template <> class Exporter<stan::rng_t&> {
     public:
-      Exporter( SEXP x ) : t(Rcpp::as<boost::random::mixmax&>(x)) {}
-      inline boost::random::mixmax& get(){ return t ; }
+      Exporter( SEXP x ) : t(Rcpp::as<stan::rng_t&>(x)) {}
+      inline stan::rng_t& get(){ return t ; }
     private:
-      boost::random::mixmax& t ;
-    } ; 
+      stan::rng_t& t ;
+    } ;
 
     template <>
-    struct input_parameter<boost::random::mixmax&> {
-      typedef typename Rcpp::ConstReferenceInputParameter<boost::random::mixmax&> type ;
-      //typedef typename boost::random::mixmax& type ;
+    struct input_parameter<stan::rng_t&> {
+      typedef typename Rcpp::ConstReferenceInputParameter<stan::rng_t&> type ;
+      //typedef typename stan::rng_t& type ;
     };
   }
 

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/random/mixmax.hpp>
+#include <stan/services/util/create_rng.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 
 #include <rstan/io/rlist_ref_var_context.hpp>
@@ -384,7 +384,7 @@ std::vector<double> unconstrained_to_constrained(Model& model,
                                                  const std::vector<double>& params) {
   std::vector<int> params_i;
   std::vector<double> constrained_params;
-  boost::random::mixmax rng = stan::services::util::create_rng(random_seed, id);
+  stan::rng_t rng = stan::services::util::create_rng(random_seed, id);
   model.write_array(rng, const_cast<std::vector<double>&>(params), params_i,
                     constrained_params);
   return constrained_params;

--- a/rstan/rstan/inst/include/rstan_next/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan_next/stan_fit.hpp
@@ -9,16 +9,16 @@
 namespace rstan {
 
 class stan_fit : public stan_fit_base {
-  
+
 private:
   SEXP model_sexp_;
   Rcpp::XPtr<stan::model::model_base> model_xptr_;
   stan::model::model_base* model_;
-  boost::random::mixmax base_rng;
+  stan::rng_t base_rng;
   const std::vector<std::string> names_;
   const std::vector<std::vector<unsigned int> > dims_;
   const unsigned int num_params_;
-  
+
   std::vector<std::string> names_oi_;                // parameters of interest
   std::vector<std::vector<unsigned int> > dims_oi_;  // and their dimensions
   std::vector<size_t> names_oi_tidx_;                // total indexes of names2
@@ -40,13 +40,13 @@ private:
    * updated.
    */
   void update_param_oi0(const std::vector<std::string>& pnames);
-  
+
 public:
   bool update_param_oi(std::vector<std::string> pnames);
-  
+
   stan_fit(SEXP model_sexp, int seed);
   ~stan_fit();
-  
+
   /**
    * Transform the parameters from its defined support
    * to unconstrained space
@@ -56,7 +56,7 @@ public:
    * @return A standard vector of doubles
    */
   std::vector<double> unconstrain_pars(Rcpp::List par);
-  
+
   /**
    * Contrary to unconstrain_pars, transform parameters
    * from unconstrained support to the constrained.
@@ -65,21 +65,21 @@ public:
    * @return A standard vector of doubles on the constrained space
    */
   std::vector<double> constrain_pars(std::vector<double> upar);
-  
+
   /**
    * Get the unconstrained or constrained parameter names
-   * 
+   *
    * @param include_tparams Flag to include transformed parameter names
    * @param include_gqs Flag to include generated quantitiy names
    * @return A standard vector of standard strings
    */
-  
-  std::vector<std::string> unconstrained_param_names(bool include_tparams, 
+
+  std::vector<std::string> unconstrained_param_names(bool include_tparams,
                                                      bool include_gqs);
-  
-  std::vector<std::string> constrained_param_names(bool include_tparams, 
+
+  std::vector<std::string> constrained_param_names(bool include_tparams,
                                                    bool include_gqs);
-  
+
   /**
    * Expose the log_prob of the model to stan_fit so R users
    * can call this function.
@@ -90,12 +90,12 @@ public:
    *   the Jacobian adjustment is included
    * @param gradient A flag to indicate whether to return the
    *   gradient as an attribute
-   * @param A numeric vector of size 1, possibly with a grad attribute      
+   * @param A numeric vector of size 1, possibly with a grad attribute
    */
-  Rcpp::NumericVector log_prob(std::vector<double> upar, 
-                               bool jacobian_adjust_transform, 
+  Rcpp::NumericVector log_prob(std::vector<double> upar,
+                               bool jacobian_adjust_transform,
                                bool gradient);
-  
+
   /**
    * Expose the grad_log_prob of the model to stan_fit so R user
    * can call this function.
@@ -104,11 +104,11 @@ public:
    *  space.
    * @param jacobian_adjust_transform A flag to indicate whether
    *   the Jacobian adjustment is included
-   * @return A numeric vector whose size is equal to the size of upar 
+   * @return A numeric vector whose size is equal to the size of upar
    */
-  Rcpp::NumericVector grad_log_prob(std::vector<double> upar, 
+  Rcpp::NumericVector grad_log_prob(std::vector<double> upar,
                                     bool jacobian_adjust_transform);
-  
+
   /**
    * Return the number of unconstrained parameters
    */
@@ -116,58 +116,58 @@ public:
 
   /**
    * Drive the sampler / optimizer / approximator
-   * 
+   *
    * @param args_ A R(cpp) list of arguments
    * @return A R(cpp) list of fit stuff
    */
-  
+
   Rcpp::List call_sampler(Rcpp::List args_);
-  
+
   /**
    * Drive the generated quantities
-   * 
+   *
    * @param draws A matrix of posterior draws
-   * @param seed An unsigned integer to seed the PRNG 
+   * @param seed An unsigned integer to seed the PRNG
    * @return A R(cpp) list of realizations from generated quantities
    */
-  
-  Rcpp::List standalone_gqs(const Eigen::Map<Eigen::MatrixXd> draws, 
+
+  Rcpp::List standalone_gqs(const Eigen::Map<Eigen::MatrixXd> draws,
                             unsigned int seed);
-  
+
   /**
    * Return names (of interest)
-   * 
+   *
    * @return A standard vector of standard strings
    */
   std::vector<std::string> param_names() const;
-  
+
   std::vector<std::string> param_names_oi() const;
-  
+
   /**
-   * Return the indices among those parameters of interest, 
+   * Return the indices among those parameters of interest,
    * rather than all the parameters
-   * 
+   *
    * @param names A standard vector of standard strings naming POIs
    * @return A R(cpp) list of indices thereof
    */
   Rcpp::List param_oi_tidx(std::vector<std::string> names);
-  
+
   /**
    * Get dimensions
-   * 
+   *
    * @return A R(cpp) list of dimensions (of interest)
    */
-  
+
   Rcpp::List param_dims() const;
-  
+
   Rcpp::List param_dims_oi() const;
 
   /**
    * Get flatnames of interest
-   * 
+   *
    * @return A standard vector of standard strings of FOIs
    */
-  
+
   std::vector<std::string> param_fnames_oi() const;
 };
 

--- a/rstan/rstan/src/Module.cpp
+++ b/rstan/rstan/src/Module.cpp
@@ -16,7 +16,7 @@ RCPP_MODULE(class_model_base) {
 }
 */
 
-inline std::vector<std::string> 
+inline std::vector<std::string>
 get_param_names(stan::model::model_base* user_model) {
   std::vector<std::string> names;
   user_model->get_param_names(names);
@@ -41,7 +41,7 @@ constrained_param_names(stan::model::model_base* user_model,
                         bool include_tparams = true,
                         bool include_gqs = true) {
   std::vector<std::string> param_names;
-  user_model->constrained_param_names(param_names, 
+  user_model->constrained_param_names(param_names,
                                       include_tparams, include_gqs);
   return param_names;
 }
@@ -51,37 +51,37 @@ unconstrained_param_names(stan::model::model_base* user_model,
                           bool include_tparams = true,
                           bool include_gqs = true) {
   std::vector<std::string> param_names;
-  user_model->unconstrained_param_names(param_names, 
+  user_model->unconstrained_param_names(param_names,
                                         include_tparams, include_gqs);
   return param_names;
 }
 
 inline double
-log_prob(stan::model::model_base* user_model, 
+log_prob(stan::model::model_base* user_model,
          std::vector<double>& params_r) {
   std::vector<int> params_i;
   return user_model->log_prob(params_r, params_i, &Rcpp::Rcout);
 }
 
 inline double
-log_prob_jacobian(stan::model::model_base* user_model, 
+log_prob_jacobian(stan::model::model_base* user_model,
                   std::vector<double>& params_r) {
   std::vector<int> params_i;
   return user_model->log_prob_jacobian(params_r, params_i, &Rcpp::Rcout);
 }
 
 inline double // this is always 0 so should we not expose it
-log_prob_propto(stan::model::model_base* user_model, 
+log_prob_propto(stan::model::model_base* user_model,
                 std::vector<double>& params_r) {
   std::vector<int> params_i;
   return user_model->log_prob_propto(params_r, params_i, &Rcpp::Rcout);
 }
 
 inline double
-log_prob_propto_jacobian(stan::model::model_base* user_model, 
+log_prob_propto_jacobian(stan::model::model_base* user_model,
                          std::vector<double>& params_r) {
   std::vector<int> params_i;
-  return user_model->log_prob_propto_jacobian(params_r, params_i, 
+  return user_model->log_prob_propto_jacobian(params_r, params_i,
                                               &Rcpp::Rcout);
 }
 
@@ -90,7 +90,7 @@ transform_inits(stan::model::model_base* user_model,
                 const rstan::io::rlist_ref_var_context context) {
   std::vector<int> params_i;
   std::vector<double> params_r;
-  user_model->transform_inits(context, params_i, params_r, 
+  user_model->transform_inits(context, params_i, params_r,
                               &Rcpp::Rcout);
   return params_r;
 }
@@ -102,8 +102,8 @@ write_array(stan::model::model_base* user_model,
             unsigned int random_seed = 0, unsigned int id = 0) {
   std::vector<int> params_i;
   std::vector<double> constrained_params;
-  boost::random::mixmax rng = stan::services::util::create_rng(random_seed, id);
-  user_model->write_array(rng, params_r, params_i, constrained_params, 
+  stan::rng_t rng = stan::services::util::create_rng(random_seed, id);
+  user_model->write_array(rng, params_r, params_i, constrained_params,
                           include_tparams, include_gqs, &Rcpp::Rcout);
   return constrained_params;
 }
@@ -113,7 +113,7 @@ write_list(stan::model::model_base* user_model,
            std::vector<double>& params_r,
            bool include_tparams = true, bool include_gqs = true,
              unsigned int random_seed = 0, unsigned int id = 0) {
-  std::vector<double> params = 
+  std::vector<double> params =
     write_array(user_model, params_r, include_tparams,
                 include_gqs, random_seed, id);
   std::vector<std::vector<size_t> > dims;
@@ -150,7 +150,7 @@ new_model(Rcpp::XPtr<stan::model::model_base> user_model) {
 
 RCPP_MODULE(class_model_base) {
   using namespace Rcpp ;
-  
+
   class_<stan::model::model_base>("model_base")
   .factory<Rcpp::XPtr<stan::model::model_base> >(new_model)
   .method("model_name", &stan::model::model_base::model_name,
@@ -198,4 +198,3 @@ RCPP_MODULE(class_model_base) {
           "parameters with the appropriate dimensions")
   ;
 }
-

--- a/rstan/rstan/src/chains.cpp
+++ b/rstan/rstan/src/chains.cpp
@@ -21,7 +21,6 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
-#include <boost/random/mixmax.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <fstream>
 

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -9,7 +9,7 @@ RcppExport SEXP get_stream_() {
 
 RcppExport SEXP get_rng_(SEXP seed) {
   int seed_ = Rcpp::as<int>(seed);
-  stan::rng_t* rng = stan::services::util::create_rng(seed_, 0);
-  Rcpp::XPtr<stan::rng_t> ptr(rng, true);
+  stan::rng_t rng = stan::services::util::create_rng(seed_, 0);
+  Rcpp::XPtr<stan::rng_t> ptr(&rng, true);
   return ptr;
 }

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -9,7 +9,7 @@ RcppExport SEXP get_stream_() {
 
 RcppExport SEXP get_rng_(SEXP seed) {
   int seed_ = Rcpp::as<int>(seed);
-  stan::rng_t* rng = new stan::rng_t(seed_);
+  stan::rng_t* rng = stan::services::util::create_rng(seed_, 0);
   Rcpp::XPtr<stan::rng_t> ptr(rng, true);
   return ptr;
 }

--- a/rstan/rstan/src/pointer-tools.cpp
+++ b/rstan/rstan/src/pointer-tools.cpp
@@ -1,5 +1,5 @@
 #include <Rcpp.h>
-#include <boost/random/mixmax.hpp>
+#include <stan/services/util/create_rng.hpp>
 
 RcppExport SEXP get_stream_() {
   std::ostream* pstream(&Rcpp::Rcout);
@@ -9,9 +9,7 @@ RcppExport SEXP get_stream_() {
 
 RcppExport SEXP get_rng_(SEXP seed) {
   int seed_ = Rcpp::as<int>(seed);
-  boost::random::mixmax* rng = new boost::random::mixmax(seed_);
-  Rcpp::XPtr<boost::random::mixmax> ptr(rng, true);
+  stan::rng_t* rng = new stan::rng_t(seed_);
+  Rcpp::XPtr<stan::rng_t> ptr(rng, true);
   return ptr;
 }
-
-

--- a/rstan/rstan/src/stan_fit.cpp
+++ b/rstan/rstan/src/stan_fit.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/random/mixmax.hpp>
+#include <stan/services/util/create_rng.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 
 #include <rstan/io/rlist_ref_var_context.hpp>
@@ -373,7 +373,7 @@ std::vector<double> unconstrained_to_constrained(stan::model::model_base* model,
                                                  const std::vector<double>& params) {
   std::vector<int> params_i;
   std::vector<double> constrained_params;
-  boost::random::mixmax rng = stan::services::util::create_rng(random_seed, id);
+  stan::rng_t rng = stan::services::util::create_rng(random_seed, id);
   model->write_array(rng, const_cast<std::vector<double>&>(params), params_i,
                      constrained_params);
   return constrained_params;
@@ -392,7 +392,7 @@ int command(stan_args& args,
             Rcpp::List& holder,
             const std::vector<size_t>& qoi_idx,
             const std::vector<std::string>& fnames_oi,
-            boost::random::mixmax& base_rng) {
+            stan::rng_t& base_rng) {
 
   stan::math::init_threadpool_tbb();
 
@@ -403,12 +403,12 @@ int command(stan_args& args,
                                    "model that has no parameters.");
   int refresh = args.get_refresh();
   unsigned int id = args.get_chain_id();
-  
+
   std::ostream nullout(nullptr);
   std::ostream& c_out = refresh ? Rcpp::Rcout : nullout;
   std::ostream& c_err = refresh ? rstan::io::rcerr : nullout;
 
-  stan::callbacks::stream_logger_with_chain_id 
+  stan::callbacks::stream_logger_with_chain_id
     logger(c_out, c_out, c_out, c_err, c_err, id);
 
   R_CheckUserInterrupt_Functor interrupt;
@@ -470,7 +470,7 @@ int command(stan_args& args,
     double epsilon = args.get_ctrl_test_grad_epsilon();
     double error = args.get_ctrl_test_grad_error();
     stan::callbacks::stream_writer sample_writer(Rcpp::Rcout);
-    
+
     return_code = stan::services::diagnose::diagnose(*model,
                                                      *init_context_ptr,
                                                      random_seed, id,
@@ -918,7 +918,7 @@ int command(stan_args& args,
 bool stan_fit::is_flatname(const std::string& name) {
     return name.find('[') != name.npos && name.find(']') != name.npos;
   }
-  
+
   /*
    * Update the parameters we are interested for the model->
    * As well, the dimensions vector for the parameters are
@@ -928,7 +928,7 @@ void stan_fit::update_param_oi0(const std::vector<std::string>& pnames) {
     names_oi_.clear();
     dims_oi_.clear();
     names_oi_tidx_.clear();
-    
+
     std::vector<unsigned int> starts;
     calc_starts(dims_, starts);
     for (std::vector<std::string>::const_iterator it = pnames.begin();
@@ -951,7 +951,7 @@ void stan_fit::update_param_oi0(const std::vector<std::string>& pnames) {
     calc_starts(dims_oi_, starts_oi_);
     num_params2_ = names_oi_tidx_.size();
   }
-  
+
 bool stan_fit::update_param_oi(std::vector<std::string> pnames) {
     if (std::find(pnames.begin(), pnames.end(), "lp__") == pnames.end())
       pnames.push_back("lp__");
@@ -959,7 +959,7 @@ bool stan_fit::update_param_oi(std::vector<std::string> pnames) {
     get_all_flatnames(names_oi_, dims_oi_, fnames_oi_, true);
     return true;
   }
-  
+
 stan_fit::stan_fit(SEXP model_sexp, int seed) :
     model_sexp_(model_sexp),
     model_xptr_(model_sexp),
@@ -999,8 +999,8 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
     model_->transform_inits(par_context, params_i, params_r, &rstan::io::rcout);
     return params_r;
   }
-  
-  
+
+
   /**
    * Contrary to unconstrain_pars, transform parameters
    * from unconstrained support to the constrained.
@@ -1023,29 +1023,29 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
     model_->write_array(base_rng, upar, params_i, par);
     return par;
   }
-  
+
   /**
    * Get the unconstrained or constrained parameter names
-   * 
+   *
    * @param include_tparams Flag to include transformed parameter names
    * @param include_gqs Flag to include generated quantitiy names
    * @return A standard vector of standard strings
    */
-  
-  std::vector<std::string> stan_fit::unconstrained_param_names(bool include_tparams, 
+
+  std::vector<std::string> stan_fit::unconstrained_param_names(bool include_tparams,
                                                      bool include_gqs) {
     std::vector<std::string> n;
     model_->unconstrained_param_names(n, include_tparams, include_gqs);
     return n;
   }
-  
-  std::vector<std::string> stan_fit::constrained_param_names(bool include_tparams, 
+
+  std::vector<std::string> stan_fit::constrained_param_names(bool include_tparams,
                                                    bool include_gqs) {
     std::vector<std::string> n;
     model_->constrained_param_names(n, include_tparams, include_gqs);
     return n;
   }
-  
+
   /**
    * Expose the log_prob of the model to stan_fit so R users
    * can call this function.
@@ -1056,10 +1056,10 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
    *   the Jacobian adjustment is included
    * @param gradient A flag to indicate whether to return the
    *   gradient as an attribute
-   * @param A numeric vector of size 1, possibly with a grad attribute      
+   * @param A numeric vector of size 1, possibly with a grad attribute
    */
-  Rcpp::NumericVector stan_fit::log_prob(std::vector<double> upar, 
-                               bool jacobian_adjust_transform, 
+  Rcpp::NumericVector stan_fit::log_prob(std::vector<double> upar,
+                               bool jacobian_adjust_transform,
                                bool gradient) {
     if (upar.size() != model_->num_params_r()) {
       std::stringstream msg;
@@ -1071,7 +1071,7 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
       throw std::domain_error(msg.str());
     }
     std::vector<int> par_i(model_->num_params_i(), 0);
-/*    
+/*
     if (!gradient) {
       double lp = 0;
       if (jacobian_adjust_transform) {
@@ -1082,17 +1082,17 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
       Rcpp::NumericVector lp2 = Rcpp::wrap(lp);
       return lp2;
     }
-*/ 
-    
+*/
+
     std::vector<double> grad;
-    double lp = jacobian_adjust_transform ? 
+    double lp = jacobian_adjust_transform ?
       stan::model::log_prob_grad<true,true >(*model_, upar, par_i, grad, &rstan::io::rcout) :
       stan::model::log_prob_grad<true,false>(*model_, upar, par_i, grad, &rstan::io::rcout);
     Rcpp::NumericVector lp2 = Rcpp::wrap(lp);
     if (gradient) lp2.attr("gradient") = grad;
     return lp2;
   }
-  
+
   /**
    * Expose the grad_log_prob of the model to stan_fit so R user
    * can call this function.
@@ -1101,9 +1101,9 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
    *  space.
    * @param jacobian_adjust_transform A flag to indicate whether
    *   the Jacobian adjustment is included
-   * @return A numeric vector whose size is equal to the size of upar 
+   * @return A numeric vector whose size is equal to the size of upar
    */
-  Rcpp::NumericVector stan_fit::grad_log_prob(std::vector<double> upar, 
+  Rcpp::NumericVector stan_fit::grad_log_prob(std::vector<double> upar,
                                     bool jacobian_adjust_transform) {
     if (upar.size() != model_->num_params_r()) {
       std::stringstream msg;
@@ -1116,14 +1116,14 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
     }
     std::vector<int> par_i(model_->num_params_i(), 0);
     std::vector<double> gradient;
-    double lp = jacobian_adjust_transform ? 
+    double lp = jacobian_adjust_transform ?
       stan::model::log_prob_grad<true,true >(*model_, upar, par_i, gradient, &rstan::io::rcout) :
       stan::model::log_prob_grad<true,false>(*model_, upar, par_i, gradient, &rstan::io::rcout);
     Rcpp::NumericVector grad = Rcpp::wrap(gradient);
     grad.attr("log_prob") = lp;
     return grad;
   }
-  
+
   /**
    * Return the number of unconstrained parameters
    */
@@ -1133,37 +1133,37 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
 
   /**
    * Drive the sampler / optimizer / approximator
-   * 
+   *
    * @param args_ A R(cpp) list of arguments
    * @return A R(cpp) list of fit stuff
    */
-  
+
   Rcpp::List stan_fit::call_sampler(Rcpp::List args_) {
     stan_args args(args_);
     Rcpp::List holder;
-    
+
     int ret = command(args, model_, holder, names_oi_tidx_,
                       fnames_oi_, base_rng);
     holder.attr("return_code") = ret;
     return holder;
   }
-  
+
   /**
    * Drive the generated quantities
-   * 
+   *
    * @param draws A matrix of posterior draws
-   * @param seed An unsigned integer to seed the PRNG 
+   * @param seed An unsigned integer to seed the PRNG
    * @return A R(cpp) list of realizations from generated quantities
    */
-  
-  Rcpp::List stan_fit::standalone_gqs(const Eigen::Map<Eigen::MatrixXd> draws, 
+
+  Rcpp::List stan_fit::standalone_gqs(const Eigen::Map<Eigen::MatrixXd> draws,
                             unsigned int seed) {
     Rcpp::List holder;
-    
+
     R_CheckUserInterrupt_Functor interrupt;
     stan::callbacks::stream_logger logger(Rcpp::Rcout, Rcpp::Rcout, Rcpp::Rcout,
                                           rstan::io::rcerr, rstan::io::rcerr);
-    
+
     std::unique_ptr<rstan_sample_writer> sample_writer_ptr;
     std::fstream sample_stream;
     std::stringstream comment_stream;
@@ -1180,35 +1180,35 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
                                                   gq_size,
                                                   draws.rows(), 0,
                                                   gq_idx));
-    
+
     int ret = stan::services::error_codes::CONFIG;
     ret = stan::services::standalone_generate(*model_, draws,
-                                              seed, interrupt, 
+                                              seed, interrupt,
                                               logger, *sample_writer_ptr);
-    
+
     holder = Rcpp::List(sample_writer_ptr->values_.x().begin(),
                         sample_writer_ptr->values_.x().end());
-    
+
     return holder;
   }
-  
+
   /**
    * Return names (of interest)
-   * 
+   *
    * @return A standard vector of standard strings
    */
   std::vector<std::string> stan_fit::param_names() const {
     return names_;
   }
-  
+
   std::vector<std::string> stan_fit::param_names_oi() const {
     return names_oi_;
   }
-  
+
   /**
-   * Return the indices among those parameters of interest, 
+   * Return the indices among those parameters of interest,
    * rather than all the parameters
-   * 
+   *
    * @param names A standard vector of standard strings naming POIs
    * @return A R(cpp) list of indices thereof
    */
@@ -1246,19 +1246,19 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
     lst.names() = names2;
     return lst;
   }
-  
+
   /**
    * Get dimensions
-   * 
+   *
    * @return A R(cpp) list of dimensions (of interest)
    */
-  
+
   Rcpp::List stan_fit::param_dims() const {
     Rcpp::List lst = Rcpp::wrap(dims_);
     lst.names() = names_;
     return lst;
   }
-  
+
   Rcpp::List stan_fit::param_dims_oi() const {
     Rcpp::List lst = Rcpp::wrap(dims_oi_);
     lst.names() = names_oi_;
@@ -1267,10 +1267,10 @@ std::vector<double> stan_fit::unconstrain_pars(Rcpp::List par) {
 
   /**
    * Get flatnames of interest
-   * 
+   *
    * @return A standard vector of standard strings of FOIs
    */
-  
+
   std::vector<std::string> stan_fit::param_fnames_oi() const {
     std::vector<std::string> fnames;
     get_all_flatnames(names_oi_, dims_oi_, fnames, true);


### PR DESCRIPTION
#### Summary:

Helps future-proof changes to Stan's RNG by using the `stan::rng_t` typedef


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
