### PR TITLE
Remove # processing to match CRAN RStan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
           - {os: macOS-latest, r: 'devel'}

--- a/rstan/rstan/R/stanc.R
+++ b/rstan/rstan/R/stanc.R
@@ -83,28 +83,7 @@ stanc_process <- function(file, model_code = '', model_name = "anon_model",
   }
 
   model_code <- gsub('#include /(.*$)', '#include "\\1"', model_code)
-  has_pound <- any(grepl("#", model_code, fixed = TRUE))
-
-  if (has_pound && isFALSE(auto_format)) {
-    unprocessed <- tempfile(fileext = ".stan")
-    processed <- tempfile(fileext = ".stan")
-    on.exit(file.remove(unprocessed))
-    writeLines(model_code, con = unprocessed)
-    ARGS <- paste("-E -nostdinc -x c++ -P -C",
-                  paste("-I", isystem, " ", collapse = ""),
-                  "-o", processed, unprocessed, "-Wno-invalid-pp-token")
-    CPP <- system2(file.path(R.home(component = "bin"), "R"),
-                   args = "CMD config CC", stdout = TRUE)
-    pkgbuild::with_build_tools(system(paste(CPP, ARGS),
-                                      ignore.stdout = TRUE, ignore.stderr = TRUE),
-                               required = rstan_options("required") &&
-                                 identical(Sys.getenv("WINDOWS"), "TRUE") &&
-                                !identical(Sys.getenv("R_PACKAGE_SOURCE"), "") )
-    if (file.exists(processed)) {
-      on.exit(file.remove(processed), add = TRUE)
-      model_code <- paste(readLines(processed), collapse = "\n")
-    }
-  } else model_code <- paste(model_code, collapse = "\n")
+  model_code <- paste(model_code, collapse = "\n")
 
   mostattributes(model_code) <- model_attr
 


### PR DESCRIPTION
#### Summary:

The most recent CRAN update (2.32.7) disabled the extra handling of `#` characters, so removing the relevant code in `develop` to match

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
