### PR TITLE
Fix accidental forcing of c++14 on windows

### DIFF
--- a/rstan/rstan/R/plugin.R
+++ b/rstan/rstan/R/plugin.R
@@ -60,8 +60,7 @@ PKG_CPPFLAGS_env_fun <- function() {
          ' -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION ',
          ' -D_HAS_AUTO_PTR_ETC=0 ',
          ' -include ', shQuote(Eigen), ' ',
-         ifelse (.Platform$OS.type == "windows", ' -std=c++1y',
-                 ' -D_REENTRANT -DRCPP_PARALLEL_USE_TBB=1 '),
+         ' -D_REENTRANT -DRCPP_PARALLEL_USE_TBB=1',
          sep = '')
 }
 
@@ -121,19 +120,12 @@ rstanplugin <- function() {
               paste0("-L", shQuote(RcppParallel_pkg_libs)),
               tbb_libs,
               utils::capture.output(RcppParallel::RcppParallelLibs()))
-  if (.Platform$OS.type == "windows") {
-    list(includes = '// [[Rcpp::plugins(cpp14)]]\n',
+
+    list(includes = '// [[Rcpp::plugins(cpp17)]]\n',
          body = function(x) x,
          env = list(PKG_LIBS = PL,
                     PKG_CPPFLAGS = paste(Rcpp_plugin$env$PKG_CPPFLAGS,
                                          PKG_CPPFLAGS_env_fun(), collapse = " ")))
-  } else {
-    list(includes = '// [[Rcpp::plugins(cpp14)]]\n',
-         body = function(x) x,
-         env = list(PKG_LIBS = PL,
-                    PKG_CPPFLAGS = paste(Rcpp_plugin$env$PKG_CPPFLAGS,
-                                         PKG_CPPFLAGS_env_fun(), collapse = " ")))
-  }
 }
 
 


### PR DESCRIPTION
#### Summary:

There have been sporadic bug reports of compile errors on windows ([like this one](https://discourse.mc-stan.org/t/error-in-compilecode/39483)).

Finally managed to reproduce the issue as being caused by the `std=c++1y` flag being passed on Windows, which causes issues with new usages of c++17 constructs (the main one being `std::void_t` for this issue)

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
