### PR TITLE
Add AI Contribution Policy reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ See [how to work with stan submodule in rstan repo](https://github.com/stan-dev/
 
 ### Licensing
 
-RStan is licensed under GPLv3.  The Stan code packaged in RStan is licensed under new BSD.   
+RStan is licensed under GPLv3.  The Stan code packaged in RStan is licensed under new BSD.
+
+All contributions must follow the [Stan AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy).


### PR DESCRIPTION
#### Summary:
Adds a reference to the Stan AI Contribution Policy  (see Stan-wiki: https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)  to the README so contributors are aware of it before submitting PRs.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Aalto university

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
