### PR TITLE
Fix compatibility with new stanc js

### DIFF
--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -22,10 +22,14 @@ OUT <- 0
 .onLoad <- function(libname, pkgname) {
   # avoid conflict between parallel and processx
   Sys.setenv(PROCESSX_NOTIFY_OLD_SIGCHLD = 1)
-  
+
   if (requireNamespace("V8", quietly = TRUE)) {
     assign("stanc_ctx", V8::v8(), envir = topenv())
-  } else assign("stanc_ctx", QuickJSR::JSContext$new(stack_size = 4 * 1024 * 1024), envir = topenv())
+  } else {
+    assign("stanc_ctx", QuickJSR::JSContext$new(), envir = topenv())
+    # Empty shims are needed for (unused) Intl calls in generated js
+    stanc_ctx$source(code="globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
+  }
 
   if (packageVersion("StanHeaders") == "2.26.28") {
     stanc_js <- system.file("exec", "stanc.js", package = "rstan", mustWork = TRUE)

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -27,9 +27,9 @@ OUT <- 0
     assign("stanc_ctx", V8::v8(), envir = topenv())
   } else {
     assign("stanc_ctx", QuickJSR::JSContext$new(), envir = topenv())
-    # Empty shims are needed for (unused) Intl calls in generated js
-    stanc_ctx$source(code="globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
   }
+  # Empty shims are needed for (unused) Intl calls in generated js
+  stanc_ctx$source(code="globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
 
   if (packageVersion("StanHeaders") == "2.26.28") {
     stanc_js <- system.file("exec", "stanc.js", package = "rstan", mustWork = TRUE)

--- a/rstan/rstan/R/zzz.R
+++ b/rstan/rstan/R/zzz.R
@@ -25,11 +25,13 @@ OUT <- 0
 
   if (requireNamespace("V8", quietly = TRUE)) {
     assign("stanc_ctx", V8::v8(), envir = topenv())
+    # Empty shims are needed for (unused) Intl calls in generated js
+    stanc_ctx$eval("globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
   } else {
     assign("stanc_ctx", QuickJSR::JSContext$new(), envir = topenv())
+    # Empty shims are needed for (unused) Intl calls in generated js
+    stanc_ctx$source(code="globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
   }
-  # Empty shims are needed for (unused) Intl calls in generated js
-  stanc_ctx$source(code="globalThis.Intl = { DateTimeFormat: { prototype: {}}}")
 
   if (packageVersion("StanHeaders") == "2.26.28") {
     stanc_js <- system.file("exec", "stanc.js", package = "rstan", mustWork = TRUE)


### PR DESCRIPTION
#### Summary:

The `stanc.js` code generated since the Ocaml 5.5 update includes calls to `Intl` functions in the initialising of a polyfill for timezone handling, but unfortunately quickjs does not support the `Intl` lib - causing the [current develop breakages](https://github.com/stan-dev/rstan/actions/runs/29034900807) ([stanc3 issue](https://github.com/stan-dev/stanc3/issues/1640)).

This PR adds an empty object for `Intl.DateTimeFormat` so that the polyfill can be initialised, `stanc` doesn't rely on any timezone functionality so no impact on stan is expected.

#### Intended Effect:

Re-enable `rstan` usage with `QuickJSR`

#### Reviewer Suggestions: Andrew Johnson

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
