### PR TITLE
Add workflow for checking rstan and/or StanHeaders reverse-dependency status

### DIFF
--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -149,7 +149,8 @@ jobs:
           curr_deps <- jsonlite::fromJSON('${{ matrix.deps }}')
 
           # Install any system dependencies needed for packages
-          pak::sysreqs_fix_installed(curr_deps)
+          rec_deps <- unique(do.call(c, tools::package_dependencies(curr_deps, which = 'all')))
+          pak::sysreqs_fix_installed(rec_deps)
           system("sudo apt-get install -y pandoc")
 
           dir.create("testdir")

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Reverse Dependencies
-run-name: Reverse Dependencies (${{ inputs.package || 'StanHeaders' }}@${{ github.sha }})
+run-name: Reverse Dependencies (${{ inputs.package || 'rstan' }}@${{ github.sha }})
 on:
   workflow_dispatch:
     inputs:
@@ -14,9 +14,9 @@ on:
           - rstan
           - StanHeaders
       batch-size:
-        description: 'Number of packages to check in each batch (default is 3)'
+        description: 'Number of packages to check in each batch (default is 10)'
         required: false
-        default: 3
+        default: 10
         type: number
       max-parallel:
         description: 'Max number of parallel jobs to use for checking (default is 5)'
@@ -48,8 +48,8 @@ jobs:
       - name: Download recursive dependencies, batch dependencies to check
         id: dep-batches
         run: |
-          batch_size <- ${{ inputs.batch-size || 3 }}
-          pkg <- "${{ inputs.package || 'StanHeaders' }}"
+          batch_size <- ${{ inputs.batch-size || 10 }}
+          pkg <- "${{ inputs.package || 'rstan' }}"
           
           # Parallelise building as much as possible
           options(Ncpus = parallel::detectCores())
@@ -196,7 +196,8 @@ jobs:
           all_pkgs <- gsub("^\\./(.*)\\.Rcheck", "\\1", list.dirs(".", recursive = FALSE))
 
           install_failures <- unique(res$Package[res$Check == "whether package can be installed"])
-          check_failures <- unique(res$Package[res$Check %in% c("tests", "re-building of vignette outputs", "examples")])
+          check_statuses <- c("tests", "re-building of vignette outputs", "examples", "examples with --run-donttest")
+          check_failures <- unique(res$Package[res$Check %in% check_statuses])
 
           summary_tbl <- knitr::kable(
             data.frame(
@@ -239,31 +240,6 @@ jobs:
           }) |>
             paste0(collapse = "\n")
             
-          all_logs <- sapply(all_pkgs, \(pkg) {
-              paste0(c(
-                paste0("### ", pkg),
-                "<details>",
-                "<summary>Install Log</summary>",
-                "",
-                "```",
-                paste0(readLines(paste0(pkg, ".Rcheck/00install.out")), collapse = "\n"),
-                "```",
-                "",
-                "</details>\n",
-                "<details>",
-                "<summary>Check Log</summary>",
-                "",
-                "```",
-                paste0(readLines(paste0(pkg, ".Rcheck/00check.log")), collapse = "\n"),
-                "```",
-                "",
-                "</details>\n"),
-                collapse = "\n"
-              )
-            }) |>
-              paste0(collapse = "\n")
-            
-
           result_md <- paste0(c(
             "# Reverse-Dependency Status",
             "## Summary",
@@ -271,9 +247,7 @@ jobs:
             "## Install Failures",
             install_logs,
             "## Vignette/Test Failures",
-            check_logs,
-            "## All Results",
-            all_logs),
+            check_logs),
             collapse = "\n"
           )
           cat(result_md, file = Sys.getenv("GITHUB_STEP_SUMMARY"), append = TRUE)

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,0 +1,287 @@
+---
+
+name: Reverse Dependencies
+run-name: Reverse Dependencies (${{ inputs.package || 'StanHeaders' }}@${{ github.sha }})
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Check rstan or just StanHeaders (default is rstan)'
+        required: false
+        default: 'rstan'
+        type: choice
+        options:
+          - rstan
+          - StanHeaders
+      batch-size:
+        description: 'Number of packages to check in each batch (default is 3)'
+        required: false
+        default: 3
+        type: number
+      max-parallel:
+        description: 'Max number of parallel jobs to use for checking (default is 5)'
+        required: false
+        default: 5
+        type: number
+  push:
+    branches:
+      - revdeps-checking
+
+jobs:
+  prepare-library:
+    runs-on: ubuntu-latest
+    name: Build & Cache Package Dependencies
+    outputs:
+      deps_matrix: ${{ steps.dep-batches.outputs.deps_matrix }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Download recursive dependencies, batch dependencies to check
+        id: dep-batches
+        run: |
+          batch_size <- ${{ inputs.batch-size || 3 }}
+          pkg <- "${{ inputs.package || 'StanHeaders' }}"
+          
+          # Parallelise building as much as possible
+          options(Ncpus = parallel::detectCores())
+          Sys.setenv(MAKEFLAGS = paste0("-j", parallel::detectCores()))
+
+          # Initialise a standalone library
+          dir.create("/tmp/PakLibrary")
+          .libPaths(c("/tmp/PakLibrary", .libPaths()))
+          install.packages(c("pak", "rstantools"))
+
+          # Lookup and (attempt to) install all dependencies for reverse-dependencies
+          pkg_deps <- tools::package_dependencies(pkg, reverse = TRUE)[[pkg]]
+          rec_deps <- unique(do.call(c, tools::package_dependencies(pkg_deps, which = 'all')))
+          install.packages(rec_deps)
+
+          # Remaining packages will be bioconductor or other non-CRAN packages, install manually
+          rec_deps <- rec_deps[!(rec_deps %in% installed.packages()[,"Package"])]
+          rec_deps <- rec_deps[!(rec_deps %in% c("blavsam", "eggCountsExtra", "BRugs", "cmdstanr", "INLA"))]
+          download.file(
+            url = "https://inla.r-inla-download.org/R/stable/src/contrib/INLA_25.10.19.tar.gz",
+            destfile = "INLA_25.10.19.tar.gz",
+            mode = "wb"
+          )
+
+          pak::pak(c(
+            rec_deps,
+            "github::stan-dev/cmdstanr",
+            "github::ecmerkle/blavsam",
+            "github::CraigWangStat/eggCountsExtra",
+            "local::./INLA_25.10.19.tar.gz"
+          ))
+
+          # Install dev versions last so that they're not used for any dependencies
+          pak::pak("local::./StanHeaders")
+          if (pkg == "rstan") {
+            pak::pak("local::./rstan/rstan")
+          }
+
+          # Split dependencies into requested batch size and
+          # restructure into format for actions 'matrix' argument
+          curr_deps <- split(pkg_deps, ceiling(seq_along(pkg_deps) / batch_size))
+          deps_matrix <- list()
+          for (i in seq_along(curr_deps)) {
+            deps_matrix[[i]] <- list(group = i, deps = jsonlite::toJSON(curr_deps[[i]]))
+          }
+          cat(paste0("deps_matrix=", jsonlite::toJSON(list(include = deps_matrix), auto_unbox = TRUE)),
+              file=Sys.getenv("GITHUB_OUTPUT"), append = TRUE)
+        shell: Rscript {0}
+
+      - name: Cache built packages
+        uses: actions/cache/save@v6
+        with:
+          path: /tmp/PakLibrary/
+          key: ${{ github.run_id }}
+
+  reverse-dependencies:
+    needs: prepare-library
+    runs-on: ubuntu-latest
+    name: Check Reverse Dependencies (Batch ${{ matrix.group }})
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ inputs.max-parallel || 5 }}
+      matrix: ${{ fromJson(needs.prepare-library.outputs.deps_matrix) }}
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      _R_CHECK_FORCE_SUGGESTS_: false
+      R_LIBS_USER: /tmp/PakLibrary
+      NOT_CRAN:
+      _R_CHECK_CRAN_INCOMING_: false
+      _R_CHECK_CRAN_INCOMING_REMOTE_: false
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Restore built library
+        uses: actions/cache/restore@v6
+        with:
+          path: /tmp/PakLibrary/
+          key: ${{ github.run_id }}
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          
+      - name: Configure Makevars
+        run: |
+          mkdir -p ~/.R
+          cat <<EOF > ~/.R/Makevars
+          # Eigen warnings significantly bloat log size, so ignore
+          CXXFLAGS += -w
+          CXX17FLAGS += -w
+          EOF
+
+      - name: Run reverse-dependency checks
+        env:
+          R_LIBS_USER: /tmp/PakLibrary
+          NOT_CRAN:
+          _R_CHECK_CRAN_INCOMING_: false
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
+          curr_deps <- jsonlite::fromJSON('${{ matrix.deps }}')
+
+          # Install any system dependencies needed for packages
+          pak::sysreqs_fix_installed(curr_deps)
+          system("sudo apt-get install -y pandoc")
+
+          dir.create("testdir")
+          download.packages(curr_deps, "testdir", repos = "https://cran.rstudio.com")
+          Sys.unsetenv("NOT_CRAN")
+          tools::check_packages_in_dir("testdir", check_args = "--as-cran --no-manual", Ncpus = 3)
+        shell: Rscript {0}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: checkresults-${{ matrix.group }}
+          path: |
+            testdir/**/00check.log
+            testdir/**/00install.out
+          compression-level: 9
+          retention-days: 1
+
+  summarise-results:
+    name: Summarise Results
+    needs: reverse-dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v7
+        with:
+          path: checkresults
+          pattern: checkresults-*
+          merge-multiple: true
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Generate results summary output
+        run: |
+          setwd("checkresults")
+          install.packages("knitr")
+
+          res <- tools::check_packages_in_dir_details(".")
+          all_pkgs <- gsub("^\\./(.*)\\.Rcheck", "\\1", list.dirs(".", recursive = FALSE))
+
+          install_failures <- unique(res$Package[res$Check == "whether package can be installed"])
+          check_failures <- unique(res$Package[res$Check %in% c("tests", "re-building of vignette outputs", "examples")])
+
+          summary_tbl <- knitr::kable(
+            data.frame(
+              "OK" = length(setdiff(all_pkgs, c(install_failures, check_failures))),
+              "Install Failed" = length(install_failures),
+              "Tests/Vignettes/Examples Failed" = length(check_failures),
+              check.names = FALSE
+            )
+          )
+
+          install_logs <- sapply(install_failures, \(pkg) {
+            paste0(c(
+              paste("###", pkg),
+              "<details>",
+              "<summary>Install Log</summary>",
+              "",
+              "```",
+              paste0(readLines(paste0(pkg, ".Rcheck/00install.out")), collapse = "\n"),
+              "```",
+              "",
+              "</details>\n"),
+              collapse = "\n"
+            )
+          }) |>
+            paste0(collapse = "\n")
+
+          check_logs <- sapply(check_failures, \(pkg) {
+            paste0(c(
+              paste("###", pkg),
+              "<details>",
+              "<summary>Check Log</summary>",
+              "",
+              "```",
+              paste0(readLines(paste0(pkg, ".Rcheck/00check.log")), collapse = "\n"),
+              "```",
+              "",
+              "</details>"),
+              collapse = "\n"
+            )
+          }) |>
+            paste0(collapse = "\n")
+            
+          all_logs <- sapply(all_pkgs, \(pkg) {
+              paste0(c(
+                paste0("### ", pkg),
+                "<details>",
+                "<summary>Install Log</summary>",
+                "",
+                "```",
+                paste0(readLines(paste0(pkg, ".Rcheck/00install.out")), collapse = "\n"),
+                "```",
+                "",
+                "</details>\n",
+                "<details>",
+                "<summary>Check Log</summary>",
+                "",
+                "```",
+                paste0(readLines(paste0(pkg, ".Rcheck/00check.log")), collapse = "\n"),
+                "```",
+                "",
+                "</details>\n"),
+                collapse = "\n"
+              )
+            }) |>
+              paste0(collapse = "\n")
+            
+
+          result_md <- paste0(c(
+            "# Reverse-Dependency Status",
+            "## Summary",
+            summary_tbl,
+            "## Install Failures",
+            install_logs,
+            "## Vignette/Test Failures",
+            check_logs,
+            "## All Results",
+            all_logs),
+            collapse = "\n"
+          )
+          cat(result_md, file = Sys.getenv("GITHUB_STEP_SUMMARY"), append = TRUE)
+        shell: Rscript {0}
+        
+      - name: Upload combined results
+        uses: actions/upload-artifact@v7
+        with:
+          name: all-logs
+          path: checkresults
+          compression-level: 9

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Reverse Dependencies
-run-name: Reverse Dependencies (${{ inputs.package || 'rstan' }}@${{ github.sha }})
+run-name: Reverse Dependencies (${{ inputs.package || 'StanHeaders' }}@${{ github.sha }})
 on:
   workflow_dispatch:
     inputs:
@@ -49,7 +49,7 @@ jobs:
         id: dep-batches
         run: |
           batch_size <- ${{ inputs.batch-size || 10 }}
-          pkg <- "${{ inputs.package || 'rstan' }}"
+          pkg <- "${{ inputs.package || 'StanHeaders' }}"
           
           # Parallelise building as much as possible
           options(Ncpus = parallel::detectCores())

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -150,7 +150,7 @@ jobs:
 
           # Install any system dependencies needed for packages
           rec_deps <- unique(do.call(c, tools::package_dependencies(curr_deps, which = 'all')))
-          pak::sysreqs_fix_installed(rec_deps)
+          pak::sysreqs_fix_installed(c(curr_deps, rec_deps))
           system("sudo apt-get install -y pandoc")
 
           dir.create("testdir")

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Reverse Dependencies
-run-name: Reverse Dependencies (${{ inputs.package || 'rstan' }}@${{ github.sha }})
+run-name: Reverse Dependencies (${{ inputs.package }}@${{ github.sha }})
 on:
   workflow_dispatch:
     inputs:
@@ -18,11 +18,21 @@ on:
         required: false
         default: 10
         type: number
-      max-parallel:
-        description: 'Max number of parallel jobs to use for checking (default is 5)'
+      pkg-source:
+        description: 'Source to use for rstan/StanHeaders (either a git ref or "CRAN", default is develop)'
         required: false
-        default: 5
-        type: number
+        default: 'develop'
+        type: string
+      rstantools-source:
+        description: Source to use for rstantools (either a git ref or "CRAN", default is CRAN)'
+        required: false
+        default: 'CRAN'
+        type: string
+      run-donttest:
+        description: 'Run `donttest` examples for each package (increasing check time), default is false'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare-library:
@@ -37,6 +47,22 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          repository: stan-dev/rstan
+          ref: ${{ (inputs.pkg-source == 'CRAN' || inputs.pkg-source == 'cran') && 'develop' || inputs.pkg-source }}
+
+
+      - name: Restore cached INLA source
+        id: cache-inla
+        uses: actions/cache@v6
+        with:
+          path: /tmp/INLA_25.10.19.tar.gz
+          key: inla-25.10.19
+
+      - name: Download INLA source if not cached
+        if: steps.cache-inla.outputs.cache-hit != 'true'
+        run: |
+          wget https://inla.r-inla-download.org/R/stable/src/contrib/INLA_25.10.19.tar.gz -O /tmp/INLA_25.10.19.tar.gz
+          
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -45,46 +71,41 @@ jobs:
       - name: Download recursive dependencies, batch dependencies to check
         id: dep-batches
         run: |
-          batch_size <- ${{ inputs.batch-size || 10 }}
-          pkg <- "${{ inputs.package || 'rstan' }}"
-          
+          batch_size <- ${{ inputs.batch-size }}
+          pkg <- "${{ inputs.package }}"
           # Parallelise building as much as possible
           options(Ncpus = parallel::detectCores())
           Sys.setenv(MAKEFLAGS = paste0("-j", parallel::detectCores()))
-
           # Initialise a standalone library
           dir.create("/tmp/PakLibrary")
           .libPaths(c("/tmp/PakLibrary", .libPaths()))
+          system("sudo apt-get install -y libcurl4-openssl-dev")
           install.packages(c("pak", "rstantools"))
-
           # Lookup and (attempt to) install all dependencies for reverse-dependencies
           pkg_deps <- tools::package_dependencies(pkg, reverse = TRUE)[[pkg]]
           rec_deps <- unique(do.call(c, tools::package_dependencies(pkg_deps, which = 'all')))
           install.packages(rec_deps)
-
           # Remaining packages will be bioconductor or other non-CRAN packages, install manually
           rec_deps <- rec_deps[!(rec_deps %in% installed.packages()[,"Package"])]
           rec_deps <- rec_deps[!(rec_deps %in% c("blavsam", "eggCountsExtra", "BRugs", "cmdstanr", "INLA"))]
-          download.file(
-            url = "https://inla.r-inla-download.org/R/stable/src/contrib/INLA_25.10.19.tar.gz",
-            destfile = "INLA_25.10.19.tar.gz",
-            mode = "wb"
-          )
 
           pak::pak(c(
             rec_deps,
             "github::stan-dev/cmdstanr",
             "github::ecmerkle/blavsam",
             "github::CraigWangStat/eggCountsExtra",
-            "local::./INLA_25.10.19.tar.gz"
+            "local::/tmp/INLA_25.10.19.tar.gz",
+            "any::qgraph"
           ))
-
           # Install dev versions last so that they're not used for any dependencies
           pak::pak("local::./StanHeaders")
           if (pkg == "rstan") {
             pak::pak("local::./rstan/rstan")
           }
-
+          rstantools_src <- "${{ inputs.rstantools-source || 'CRAN'}}"
+          if (tolower(rstantools_src) != "cran") {
+            pak::pak(paste0("stan-dev/rstantools@", rstantools_src))
+          }
           # Split dependencies into requested batch size and
           # restructure into format for actions 'matrix' argument
           curr_deps <- split(pkg_deps, ceiling(seq_along(pkg_deps) / batch_size))
@@ -108,7 +129,7 @@ jobs:
     name: Check Reverse Dependencies (Batch ${{ matrix.group }})
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max-parallel || 5 }}
+      max-parallel: 10
       matrix: ${{ fromJson(needs.prepare-library.outputs.deps_matrix) }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -117,6 +138,9 @@ jobs:
       NOT_CRAN:
       _R_CHECK_CRAN_INCOMING_: false
       _R_CHECK_CRAN_INCOMING_REMOTE_: false
+      _R_CHECK_DONTTEST_EXAMPLES_: ${{ inputs.run-donttest }}
+      _R_CHECK_ELAPSED_TIMEOUT_: 1h
+      _R_CHECK_SYSTEM_CLOCK_: 0
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -129,7 +153,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
-          
+
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - name: Configure Makevars
         run: |
           mkdir -p ~/.R
@@ -139,24 +166,31 @@ jobs:
           CXX17FLAGS += -w
           EOF
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y pandoc libudunits2-dev libglpk-dev libgsl0-dev \
+               texlive-latex-base texlive-latex-recommended texlive-fonts-extra \
+               texlive-fonts-recommended texlive-luatex texlive-latex-extra \
+               texlive-bibtex-extra
+  
       - name: Run reverse-dependency checks
         env:
           R_LIBS_USER: /tmp/PakLibrary
           NOT_CRAN:
           _R_CHECK_CRAN_INCOMING_: false
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          _R_CHECK_DONTTEST_EXAMPLES_: ${{ inputs.run-donttest }}
+          _R_CHECK_ELAPSED_TIMEOUT_: 1h
+          _R_CHECK_SYSTEM_CLOCK_: 0
         run: |
           curr_deps <- jsonlite::fromJSON('${{ matrix.deps }}')
-
           # Install any system dependencies needed for packages
           rec_deps <- unique(do.call(c, tools::package_dependencies(curr_deps, which = 'all')))
           pak::sysreqs_fix_installed(c(curr_deps, rec_deps))
-          system("sudo apt-get install -y pandoc")
-
           dir.create("testdir")
           download.packages(curr_deps, "testdir", repos = "https://cran.rstudio.com")
           Sys.unsetenv("NOT_CRAN")
-          tools::check_packages_in_dir("testdir", check_args = "--as-cran --no-manual", Ncpus = 3)
+          tools::check_packages_in_dir("testdir", check_args = "--as-cran --no-manual", Ncpus = parallel::detectCores() - 1)
         shell: Rscript {0}
 
       - uses: actions/upload-artifact@v7
@@ -189,14 +223,13 @@ jobs:
         run: |
           setwd("checkresults")
           install.packages("knitr")
-
           res <- tools::check_packages_in_dir_details(".")
           all_pkgs <- gsub("^\\./(.*)\\.Rcheck", "\\1", list.dirs(".", recursive = FALSE))
-
           install_failures <- unique(res$Package[res$Check == "whether package can be installed"])
+          install_failures <- install_failures[order(install_failures)]
           check_statuses <- c("tests", "re-building of vignette outputs", "examples", "examples with --run-donttest")
           check_failures <- unique(res$Package[res$Check %in% check_statuses])
-
+          check_failures <- check_failures[order(check_failures)]
           summary_tbl <- knitr::kable(
             data.frame(
               "OK" = length(setdiff(all_pkgs, c(install_failures, check_failures))),
@@ -205,7 +238,6 @@ jobs:
               check.names = FALSE
             )
           )
-
           install_logs <- sapply(install_failures, \(pkg) {
             paste0(c(
               paste("###", pkg),
@@ -221,7 +253,6 @@ jobs:
             )
           }) |>
             paste0(collapse = "\n")
-
           check_logs <- sapply(check_failures, \(pkg) {
             paste0(c(
               "",
@@ -239,12 +270,11 @@ jobs:
             )
           }) |>
             paste0(collapse = "\n")
-            
           result_md <- paste0(c(
             "# Reverse-Dependency Status\n",
             "## Summary\n",
             summary_tbl,
-            "## Install Failure\ns",
+            "## Install Failure\n",
             install_logs,
             "## Vignette/Test Failures\n",
             check_logs),
@@ -252,7 +282,7 @@ jobs:
           )
           cat(result_md, file = Sys.getenv("GITHUB_STEP_SUMMARY"), append = TRUE)
         shell: Rscript {0}
-        
+
       - name: Upload combined results
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Reverse Dependencies
-run-name: Reverse Dependencies (${{ inputs.package || 'StanHeaders' }}@${{ github.sha }})
+run-name: Reverse Dependencies (${{ inputs.package || 'rstan' }}@${{ github.sha }})
 on:
   workflow_dispatch:
     inputs:
@@ -23,9 +23,6 @@ on:
         required: false
         default: 5
         type: number
-  push:
-    branches:
-      - revdeps-checking
 
 jobs:
   prepare-library:
@@ -49,7 +46,7 @@ jobs:
         id: dep-batches
         run: |
           batch_size <- ${{ inputs.batch-size || 10 }}
-          pkg <- "${{ inputs.package || 'StanHeaders' }}"
+          pkg <- "${{ inputs.package || 'rstan' }}"
           
           # Parallelise building as much as possible
           options(Ncpus = parallel::detectCores())
@@ -226,7 +223,9 @@ jobs:
 
           check_logs <- sapply(check_failures, \(pkg) {
             paste0(c(
+              "",
               paste("###", pkg),
+              "",
               "<details>",
               "<summary>Check Log</summary>",
               "",
@@ -234,19 +233,19 @@ jobs:
               paste0(readLines(paste0(pkg, ".Rcheck/00check.log")), collapse = "\n"),
               "```",
               "",
-              "</details>"),
+              "</details>\n"),
               collapse = "\n"
             )
           }) |>
             paste0(collapse = "\n")
             
           result_md <- paste0(c(
-            "# Reverse-Dependency Status",
-            "## Summary",
+            "# Reverse-Dependency Status\n",
+            "## Summary\n",
             summary_tbl,
-            "## Install Failures",
+            "## Install Failure\ns",
             install_logs,
-            "## Vignette/Test Failures",
+            "## Vignette/Test Failures\n",
             check_logs),
             collapse = "\n"
           )


### PR DESCRIPTION
#### Summary:

In order to make the process of getting new `rstan` up on CRAN a bit easier, I've put together an actions workflow for running the full reverse-dependency checks. Once all reverse-dependencies are consistently passing, it would be great to also include as an (infrequently) scheduled CI.

It operates in three stages:

1. The full dependency tree for all reverse-dependencies is built/downloaded, and then cached and reused in the subsequent steps
  a. Pre-built binary packages are used for almost all dependencies (~10 need to be built)

2. The list of reverse dependencies is split into batches of a specified size and batches are checked in parallel
  a. The number of dependencies to check per batch defaults to 10, but can be set when triggering workflow
  b. The maximum number of batches running in parallel is limited to 5 by default, but can also be configured

3. The results of all checks are collated and a summary generated

The job can be set to check either `rstan` (implying also development `StanHeaders`) or just `StanHeaders` (implying CRAN `rstan`).

The reverse-dependency summary is reported in the action summary itself, and all check/install logs are attached as artifacts. You can see current runs here:

  - [`StanHeaders` (CRAN `rstan`)](https://github.com/stan-dev/rstan/actions/runs/29305771788#summary-87002650623)
  - [`rstan` (GH `StanHeaders`)](https://github.com/stan-dev/rstan/actions/runs/29303013504#summary-87017662094)

Using the defaults (10 packages per batch, maximum 5 batches running at once), the `rstan` checks finished in ~3.5 hours. This might increase as the number of incompatible packages increases (currently 64 not building), but I'm hoping that the twin dials for batch size and parallelism will keep the impact fairly minimal


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
