### PR TITLE
Handle new 'converged' column in optimizing output

### DIFF
--- a/StanHeaders/DESCRIPTION
+++ b/StanHeaders/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: StanHeaders
 Title: C++ Header Files for Stan
-Version: 2.36.0.9000
+Version: 2.39.0.9000
 Authors@R: c(person("Ben",family="Goodrich", email="benjamin.goodrich@columbia.edu", role=c('cre','aut')),
              person("Joshua", "Pritikin", role = "ctb"),
              person("Andrew", "Gelman", role = "aut"),
@@ -43,3 +43,4 @@ Depends: R (>= 3.4.0)
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 RoxygenNote: 7.1.2
+Config/build/compilation-database: true

--- a/rstan/rstan/DESCRIPTION
+++ b/rstan/rstan/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rstan
 Type: Package
 Title: R Interface to Stan
-Version: 2.36.0.9000
+Version: 2.39.0.9000
 Authors@R: c(person("Jiqiang", "Guo", email = "guojq28@gmail.com", role = "aut"),
              person("Jonah", "Gabry", email = "jgabry@gmail.com", role = "aut"),
              person("Ben", "Goodrich", email = "benjamin.goodrich@columbia.edu", role = c("cre", "aut")),
@@ -73,3 +73,4 @@ SystemRequirements: GNU make, pandoc
 Encoding: UTF-8
 RoxygenNote: 7.1.2
 Config/testthat/edition: 3
+Config/build/compilation-database: true

--- a/rstan/rstan/inst/include/rstan/stan_fit.hpp
+++ b/rstan/rstan/inst/include/rstan/stan_fit.hpp
@@ -555,9 +555,11 @@ int command(stan_args& args, Model& model, Rcpp::List& holder,
     std::vector<double> params = sample_writer.x();
     double lp = params.front();
     params.erase(params.begin());
+    double converged = params.front();
+    params.erase(params.begin());
     holder = Rcpp::List::create(Rcpp::_["par"] = params,
-                                Rcpp::_["value"] = lp);
-
+                                Rcpp::_["value"] = lp,
+                                Rcpp::_["converged"] = converged);
   }
   if (args.get_method() == SAMPLING) {
     std::vector<std::string> sample_names;


### PR DESCRIPTION
#### Summary:

Stan 2.39 introduced a column `converged__` to the output of `optimize`, this new column is causing errors in calls to optimize (see #1191 for example) and will be needed for `rstan` 2.39+ on CRAN.

I've also bumped the package version to 2.39.9000 to better reflect the underlying Stan version

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
