### PR TITLE
Pre-run cleanup script for r-devel workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,9 @@ jobs:
           New-Item -Path "C:\" -Name "tmp" -ItemType Directory
           echo "TMPDIR=c:\tmp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Run StanHeaders cleanup script
+        run: cd StanHeaders && bash -x ./cleanup
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: rstan/rstan


### PR DESCRIPTION
#### Summary:

As an interim fix to unblock CI, run the `cleanup` script prior to building `StanHeaders` so that all directories are found in R-devel

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
