### PR TITLE
Add NEW_RSTAN flag for compatibility with mixing cran & r-universe packages

### DIFF
--- a/rstan/rstan/R/plugin.R
+++ b/rstan/rstan/R/plugin.R
@@ -56,6 +56,7 @@ PKG_CPPFLAGS_env_fun <- function() {
          ' -DBOOST_PENDING_INTEGER_LOG2_HPP ',
          ' -DSTAN_THREADS ',
          ' -DUSE_STANC3',
+         ' -DNEW_RSTAN',
          ' -DSTRICT_R_HEADERS ',
          ' -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION ',
          ' -D_HAS_AUTO_PTR_ETC=0 ',

--- a/rstan/rstan/src/Makevars
+++ b/rstan/rstan/src/Makevars
@@ -1,6 +1,6 @@
 CXX_STD = CXX17
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))" | tail -n 1)
-PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DUSE_STANC3 -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
+PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DNEW_RSTAN -DUSE_STANC3 -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
 PKG_CPPFLAGS += $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::CxxFlags()" | tail -n 1)
 PKG_CXXFLAGS += -DSTRICT_R_HEADERS
 SHLIB_LDFLAGS = $(SHLIB_CXXLDFLAGS)

--- a/rstan/rstan/src/Makevars.win
+++ b/rstan/rstan/src/Makevars.win
@@ -1,6 +1,6 @@
 CXX_STD = CXX17
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))" | tail -n 1)
-PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DUSE_STANC3 -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
+PKG_CPPFLAGS = -I"../inst/include" -I"../inst/include/boost_not_in_BH" -I"${STANHEADERS_SRC}" -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_REENTRANT -DSTAN_THREADS -DUSE_STANC3 -DNEW_RSTAN -DSTRICT_R_HEADERS -D_HAS_AUTO_PTR_ETC=0
 PKG_CPPFLAGS += $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::CxxFlags()" | tail -n 1)
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1 -DSTRICT_R_HEADERS
 PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::RcppParallelLibs()" | tail -n 1)


### PR DESCRIPTION
#### Summary:

Flagged in [this discourse thread](https://discourse.mc-stan.org/t/rstan-compilation-error-with-r-4-6-1-rtools45-and-rstan-2-39), users mixing CRAN `StanHeaders` with r-universe/develop `rstan` can experience compilation failures. This PR just adds the temporary `-DNEW_RSTAN` flag from the `v2.39.0` branch (which will become the next CRAN rstan) so that the two can work together.

Emphasising that this flag should be temporary - only required as part of the 2.36 -> 2.39 CRAN transition and should be removed once rstan is updated

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (https://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
